### PR TITLE
01 03 docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:8-wheezy
 ADD ./labtool2.0 /code
 WORKDIR /code
+COPY ./labtool2.0/package.json ../
+COPY ./labtool2.0/package.json ../package-lock.json
 RUN npm install
 ENV PATH=".:${PATH}"
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY ./labtool2.0/package.json ../package-lock.json
 RUN npm install
 ENV PATH=".:${PATH}"
 EXPOSE 3000
-CMD [ "react-scripts", "start" ]
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3'
 services:
   web:
-    build: .
+    image: labtool/labtool:dev
     ports:
-     - "5000:5000"
+     - "3000:3000"
     depends_on:
      - db
   db:


### PR DESCRIPTION
Noniin. Nyt on testattu, että dockerhubin image käynnistyy ok docker-compose.yml tiedostoa käytettäessä, mikä käyttää suoraan buildattua imagea reposta.

Tuotanto docker-compose.yml tiedostossa valitaan vain :production tagi ja dev alustalla :dev 