### PR TITLE
package.json script import_courses uses the running backend to get co…

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "debug": "node --inspect=0.0.0.0:9229 app.js",
     "createdb": "node_modules/.bin/sequelize db:create",
     "dropdb": "node_modules/.bin/sequelize db:drop",
+    "import_courses": "echo 'I expect to have backend running on localhost port 3001\n\n';curl -k -X POST -H 'Content-Type: application/json' http://localhost:3001/api/courseinstances/update",
     "test": "./bin/test.sh test"
   },
   "author": "",


### PR DESCRIPTION
### Short description
Added script "import_courses" to backend package.json. This should make it easier for all non-windows using project members to get the courses to the local DB. Should work on any system that has curl installed. Curl should be installed in OSX and many Linux distributions by default. Windows users would have install it separately and add the bin dir into the $PATH variable. 

To use it, have the backend started up in localhost (npm start) and then run 'npm run import_courses'

I have:
- [ ] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [x] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
