### PR TITLE
migrations for adding a boolean admin field to users and teacherInsta…

### DIFF
--- a/backend/server/migrations/20180323112009-add_boolean_admin_field_to_users.js
+++ b/backend/server/migrations/20180323112009-add_boolean_admin_field_to_users.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'admin', Sequelize.BOOLEAN, {
+      after: 'studentnumber'
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', 'admin')
+  }
+}

--- a/backend/server/migrations/20180323112727-add_boolean_admin_field_to_course_instance_teachers.js
+++ b/backend/server/migrations/20180323112727-add_boolean_admin_field_to_course_instance_teachers.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('TeacherInstances', 'admin', Sequelize.BOOLEAN, {
+      after: 'userId'
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('TeacherInstances', 'admin')
+  }
+}

--- a/backend/server/models/teacherinstance.js
+++ b/backend/server/models/teacherinstance.js
@@ -1,5 +1,10 @@
 module.exports = (sequelize, DataTypes) => {
-  const TeacherInstance = sequelize.define('TeacherInstance', {}, {})
+  const TeacherInstance = sequelize.define('TeacherInstance', {
+    admin: {
+      type: DataTypes.BOOLEAN,
+      default: false
+    }
+  }, {})
   TeacherInstance.associate = (models) => {
 
 

--- a/backend/server/models/user.js
+++ b/backend/server/models/user.js
@@ -4,7 +4,11 @@ module.exports = (sequelize, DataTypes) => {
     email: DataTypes.STRING,
     firsts: DataTypes.STRING,
     lastname: DataTypes.STRING,
-    studentnumber: DataTypes.STRING
+    studentnumber: DataTypes.STRING,
+    admin: {
+      type: DataTypes.BOOLEAN,
+      default: false
+    }
   }, {})
   User.associate = (models) => {
     User.hasMany(models.StudentInstance, {


### PR DESCRIPTION
### Short description
Added migrations for tables Users and TeacherInstances which add into both tables a boolean field named admin. In the model definition files the default value is set to be false so when adding a super user to Users table, the field has to be explicitly set to true. Same thing when the course is being created by an admin user, the course instance result that lists current students and teachers should add the teachers with admin = true when inserting into TeacherInstances.

I have:
- [x] added actual code.
- [ ] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
