### PR TITLE
Now /api/courses/:id is instead /api/courses/:ohid where :id was the …

### DIFF
--- a/backend/server/controllers/courses.js
+++ b/backend/server/controllers/courses.js
@@ -14,12 +14,11 @@ module.exports = {
   },
 
   retrieve(req, res) {
-    return Course
-      .findById(req.params.id, {
-        include: [{
-          model: CourseInstance,
-          as: 'courseInstances'
-        }],
+    return CourseInstance
+      .findAll({
+        where: {
+          ohid: req.params.ohid
+        },
       })
       .then(course => {
         if (!course) {

--- a/backend/server/controllers/courses.js
+++ b/backend/server/controllers/courses.js
@@ -15,7 +15,7 @@ module.exports = {
 
   retrieve(req, res) {
     return CourseInstance
-      .findAll({
+      .findOne({
         where: {
           ohid: req.params.ohid
         },

--- a/backend/server/routes/courseRouter.js
+++ b/backend/server/routes/courseRouter.js
@@ -3,7 +3,7 @@ const coursesController = require('../controllers').courses
 module.exports = (app) => {
   app.post('/api/courses', coursesController.create)
   app.get('/api/courses', coursesController.list)
-  app.get('/api/courses/:id', coursesController.retrieve)
+  app.get('/api/courses/:ohid', coursesController.retrieve)
   app.delete('/api/courses/:id', coursesController.destroy)
   app.put('/api/courses/:id', coursesController.update)
 }


### PR DESCRIPTION
…integer number in the database but now with the :ohid which is the textual identifier of the course

### Short description

/api/courses/:id now responds to /api/courses/:ohid 

I have:
- [x] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
