### PR TITLE
React warnings silenced

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -25,7 +25,7 @@ class BrowseReviews extends Component {
     const content = {
       hidden: e.target.hidden.checked,
       comment: e.target.content.value,
-      week: parseInt(e.target.name),
+      week: parseInt(e.target.name, 10),
       from: this.props.user.user.username
     }
     document.getElementById(e.target.name).reset()

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -111,14 +111,14 @@ class CoursePage extends Component {
                   <Table.Cell textAlign="right">
                     {' '}
                     <Link to={`/labtool/ModifyCourseInstancePage/${this.props.selectedInstance.ohid}`}>
-                      <Button circular size="tiny" icon="large orange edit icon" />
+                      <Button circular size="tiny" icon={{ name: 'edit', size: 'large', color: 'orange' }} />
                     </Link>
                   </Table.Cell>
                 </Table.Row>
               </Table.Header>
             </Table>
             <List style={{ float: 'right' }}>
-              <List.Item icon="orange edit" content="Edit course" />
+              <List.Item icon={{ name: 'edit', color: 'orange' }} content="Edit course" />
             </List>
 
             <br />
@@ -150,7 +150,7 @@ class CoursePage extends Component {
 
                     <Table.Cell textAlign="right">
                       <Link to={`/labtool/browsereviews/${this.props.selectedInstance.ohid}/${data.id}`}>
-                        <Button circular size="tiny" icon="large star orange" />
+                        <Button circular size="tiny" icon={{ name: 'star', size: 'large', color: 'orange' }} />
                       </Link>
                     </Table.Cell>
                   </Table.Row>
@@ -158,7 +158,7 @@ class CoursePage extends Component {
               </Table.Body>
             </Table>
             <List style={{ float: 'right' }}>
-              <List.Item icon="orange star" content="Review student" />
+              <List.Item icon={{ name: 'star', color: 'orange' }} content="Review student" />
             </List>
           </div>
         ) : (
@@ -193,7 +193,7 @@ class CoursePage extends Component {
               </Table.Header>
               <Table.Body>
                 {this.props.courseData.data.weeks.sort((a, b) => a.weekNumber - b.weekNumber).map(week => (
-                  <Table.Row>
+                  <Table.Row key={week.weekNumber}>
                     <Table.Cell>{week.weekNumber}</Table.Cell>
                     <Table.Cell>{week.points}</Table.Cell>
                     <Table.Cell>

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -12,7 +12,7 @@ class CoursePage extends Component {
     const content = {
       hidden: false,
       comment: e.target.content.value,
-      week: parseInt(e.target.name),
+      week: parseInt(e.target.name, 10),
       from: this.props.user.user.username
     }
     try {

--- a/labtool2.0/src/components/pages/Courses.js
+++ b/labtool2.0/src/components/pages/Courses.js
@@ -25,7 +25,7 @@ class Courses extends Component {
 
             <Table.Body>
               {this.props.courseInstance.map(instance => (
-                <Table.Row key={instance.key}>
+                <Table.Row key={instance.id}>
                   <Table.Cell>
                     <div>
                       {instance.active === true ? (
@@ -39,14 +39,14 @@ class Courses extends Component {
                   </Table.Cell>
                   <Table.Cell>{instance.ohid} </Table.Cell>
                   <Table.Cell>
-                    <bold>
+                    <strong>
                       <a href={`/labtool/courses/${instance.ohid}`}>{instance.name}</a>
-                    </bold>
+                    </strong>
                   </Table.Cell>
 
                   <Table.Cell>{instance.start.substring(0, 10)} </Table.Cell>
                   <Table.Cell textAlign="center">
-                    <Button circular size="tiny" icon="large blue eye icon" as={Link} to={`/labtool/courses/${instance.ohid}`} />
+                    <Button circular size="tiny" icon={{ name: 'eye', size: 'large', color: 'blue' }} as={Link} to={`/labtool/courses/${instance.ohid}`} />
                   </Table.Cell>
                 </Table.Row>
               ))}
@@ -55,8 +55,8 @@ class Courses extends Component {
 
           <div className="Instructions">
             <List>
-              <List.Item icon="blue eye icon" content="Show course page" />
-              <List.Item icon="green square" content="Course is activated" />
+              <List.Item icon={{ name: 'eye', color: 'blue' }} content="Show course page" />
+              <List.Item icon={{ name: 'square', color: 'green' }} content="Course is activated" />
             </List>
           </div>
         </Container>

--- a/labtool2.0/src/components/pages/LoginPage.js
+++ b/labtool2.0/src/components/pages/LoginPage.js
@@ -2,12 +2,17 @@ import { connect } from 'react-redux'
 import { login } from '../../services/login'
 import React from 'react'
 import { Form, Input, Button, Grid, Loader } from 'semantic-ui-react'
+import PropTypes from 'prop-types'
 
 /**
  *  The page used to login
  */
 
 class LoginPage extends React.Component {
+  static propTypes = {
+    login: PropTypes.func
+  }
+
   state = {
     loading: false
   }

--- a/labtool2.0/src/components/pages/LoginPage.js
+++ b/labtool2.0/src/components/pages/LoginPage.js
@@ -2,17 +2,12 @@ import { connect } from 'react-redux'
 import { login } from '../../services/login'
 import React from 'react'
 import { Form, Input, Button, Grid, Loader } from 'semantic-ui-react'
-import PropTypes from 'prop-types'
 
 /**
  *  The page used to login
  */
 
 class LoginPage extends React.Component {
-  static propTypes = {
-    login: PropTypes.func
-  }
-
   state = {
     loading: false
   }

--- a/labtool2.0/src/components/pages/MyPage.js
+++ b/labtool2.0/src/components/pages/MyPage.js
@@ -59,7 +59,7 @@ class MyPage extends Component {
                   </Table.Cell>
                   <Table.Cell textAlign="right" verticalAlign="bottom">
                     <Link to="/labtool/email">
-                      <Button circular size="tiny" icon="large blue edit icon" />
+                      <Button circular size="tiny" icon={{ name: 'edit', size: 'large', color: 'blue' }} />
                     </Link>
                   </Table.Cell>
                 </Table.Row>
@@ -70,7 +70,7 @@ class MyPage extends Component {
 
         <div className="Instructions">
           <List>
-            <List.Item icon="blue edit icon" content="Edit email address" />
+            <List.Item icon={{ name: 'edit', color: 'blue' }} content="Edit email address" />
           </List>
         </div>
 
@@ -88,11 +88,11 @@ class MyPage extends Component {
             <Table singleLine key="grey" color="yellow">
               <Table.Body>
                 {this.props.studentInstance.map(sinstance => (
-                  <Table.Row>
+                  <Table.Row key={sinstance.id}>
                     <Table.Cell>{sinstance.name}</Table.Cell>
                     <Table.Cell textAlign="right">
                       <Link to={`/labtool/courses/${sinstance.ohid}`}>
-                        <Button circular size="tiny" icon="large blue eye icon" />
+                        <Button circular size="tiny" icon={{ name: 'eye', size: 'large', color: 'blue' }} />
                       </Link>
                     </Table.Cell>
                   </Table.Row>
@@ -109,14 +109,14 @@ class MyPage extends Component {
                   My Courses (Teacher)
                 </Header>
 
-                <Table singleline key="grey" color="yellow">
+                <Table singleLine key="grey" color="yellow">
                   <Table.Body>
                     {this.props.teacherInstance.map(tinstance => (
                       <Table.Row key={tinstance.id}>
                         <Table.Cell>{tinstance.name}</Table.Cell>
                         <Table.Cell textAlign="right">
                           <Link to={`/labtool/courses/${tinstance.ohid}`}>
-                            <Button circular size="tiny" icon="large blue eye icon" />
+                            <Button circular size="tiny" icon={{ name: 'eye', size: 'large', color: 'blue' }} />
                           </Link>
                         </Table.Cell>
                       </Table.Row>
@@ -129,7 +129,7 @@ class MyPage extends Component {
         </Segment>
         <div className="Instructions">
           <List>
-            <List.Item icon="blue eye icon" content="Show course page" />
+            <List.Item icon={{ name: 'eye', color: 'blue' }} content="Show course page" />
           </List>
           <br />
           <br />


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Silence the most immediately visible react warnings by fixing the issues causing them. Add no new functionality apart from bug fixes.

parseInt requires a radix. I assume the intended radix was 10, since that's what it defaulted to anyway.

Icons with more attributes than a name should be defined by objects. Defining them by a string makes react angry (I assume due to ambiguity).

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [x] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
