### PR TITLE
Statechange in render bugfix

### DIFF
--- a/labtool2.0/src/App.js
+++ b/labtool2.0/src/App.js
@@ -17,27 +17,12 @@ import ReviewStudent from './components/pages/ReviewStudent'
 import BrowseReviews from './components/pages/BrowseReviews'
 import MyPage from './components/pages/MyPage'
 
-// Services (Backend & redux related) imports
-import { getOneCI } from './services/courseInstance'
-import { coursePageInformation } from './services/courseInstance'
-import { getAllCI } from './services/courseInstance'
-import { getAllStudentCourses } from './services/studentinstances'
-import { getAllTeacherCourses } from './services/teacherinstances'
-
 // Reducer imports
 import { logout } from './reducers/loginReducer'
 import { tokenLogin } from './reducers/loginReducer'
 
 // The main component of the whole application.
 class App extends Component {
-  /**
-   * As the component mounts, it gets all the course instances
-   * from the backend to the store.
-   */
-  componentWillMount() {
-    this.props.getAllCI()
-  }
-
   /**
    * After mounting, it checks from the localstorage if user is logged in.
    * If true, it parses the user from the storage and puts it and
@@ -50,8 +35,6 @@ class App extends Component {
       if (loggedUserJSON && loggedUserJSON !== '{}') {
         const user = JSON.parse(loggedUserJSON)
         this.props.tokenLogin(user)
-        this.props.getAllStudentCourses()
-        this.props.getAllTeacherCourses()
       }
     } catch (exception) {
       console.log(exception)
@@ -87,20 +70,15 @@ class App extends Component {
             <Route path={`/labtool/courses/:id`} render={({ match, history }) => <CoursePage history={history} courseId={match.params.id} />} />
             <Route exact path={`/labtool/courses`} render={({ history }) => <Courses history={history} />} />
             <Route path={`/labtool/courseregistration/:id`} render={({ match, history }) => <RegisterPage history={history} courseId={match.params.id} />} />
-            <Route
-              path={`/labtool/browsereviews/:id/:si/`}
-              render={({ match, history }) => (
-                <BrowseReviews history={history} courseinstance={this.props.getOneCI(match.params.id)} pageData={this.props.coursePageInformation(match.params.id)} studentInstance={match.params.si} />
-              )}
-            />
+            <Route path={`/labtool/browsereviews/:id/:si/`} render={({ match, history }) => <BrowseReviews history={history} courseId={match.params.id} studentInstance={match.params.si} />} />
             <Route path={`/labtool/email`} component={Email} />
             <Route path={`/labtool/registerPage`} component={RegisterPage} />
             <Route
               path={`/labtool/reviewstudent/:id/:si/:wk`}
-              render={({ match, history }) => <ReviewStudent history={history} courseinstance={this.props.getOneCI(match.params.id)} studentInstance={match.params.si} weekNumber={match.params.wk} />}
+              render={({ match, history }) => <ReviewStudent history={history} courseId={match.params.id} studentInstance={match.params.si} weekNumber={match.params.wk} />}
             />
             <Route path={`/labtool/ModifyCourseInstancePage/:id`} render={({ match }) => <ModifyCourseInstancePage courseId={match.params.id} />} />
-            <Route path={`/`} component={MyPage} />
+            <Route path={`/`} render={() => <MyPage />} />
           </Switch>
         </main>
       )
@@ -135,10 +113,8 @@ const mapStateToProps = state => {
   return {
     user: state.user.user,
     token: state.user.token,
-    created: state.user.created,
-    studentInstance: state.studentInstance,
-    teacherInstance: state.teacherInstance
+    created: state.user.created
   }
 }
 
-export default withRouter(connect(mapStateToProps, { getAllCI, tokenLogin, logout, getOneCI, coursePageInformation, getAllStudentCourses, getAllTeacherCourses })(App))
+export default withRouter(connect(mapStateToProps, { tokenLogin, logout })(App))

--- a/labtool2.0/src/App.js
+++ b/labtool2.0/src/App.js
@@ -84,12 +84,9 @@ class App extends Component {
       return (
         <main>
           <Switch>
-            <Route
-              path={`/labtool/courses/:id`}
-              render={({ match, history }) => <CoursePage history={history} courseinstance={this.props.getOneCI(match.params.id)} pageData={this.props.coursePageInformation(match.params.id)} />}
-            />
+            <Route path={`/labtool/courses/:id`} render={({ match, history }) => <CoursePage history={history} courseId={match.params.id} />} />
             <Route exact path={`/labtool/courses`} render={({ history }) => <Courses history={history} />} />
-            <Route path={`/labtool/courseregistration/:id`} render={({ match, history }) => <RegisterPage history={history} courseinstance={this.props.getOneCI(match.params.id)} />} />
+            <Route path={`/labtool/courseregistration/:id`} render={({ match, history }) => <RegisterPage history={history} courseId={match.params.id} />} />
             <Route
               path={`/labtool/browsereviews/:id/:si/`}
               render={({ match, history }) => (
@@ -102,7 +99,7 @@ class App extends Component {
               path={`/labtool/reviewstudent/:id/:si/:wk`}
               render={({ match, history }) => <ReviewStudent history={history} courseinstance={this.props.getOneCI(match.params.id)} studentInstance={match.params.si} weekNumber={match.params.wk} />}
             />
-            <Route path={`/labtool/ModifyCourseInstancePage/:id`} render={({ match }) => <ModifyCourseInstancePage courseinstance={this.props.getOneCI(match.params.id)} />} />
+            <Route path={`/labtool/ModifyCourseInstancePage/:id`} render={({ match }) => <ModifyCourseInstancePage courseId={match.params.id} />} />
             <Route path={`/`} component={MyPage} />
           </Switch>
         </main>

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -3,7 +3,7 @@ import { Button, Card, Accordion, Icon, Form, Comment } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { createOneComment } from '../../services/comment'
-import { coursePageInformation } from '../../services/courseInstance'
+import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import ReactMarkdown from 'react-markdown'
 
 /**
@@ -11,6 +11,11 @@ import ReactMarkdown from 'react-markdown'
  */
 class BrowseReviews extends Component {
   state = { activeIndex: 0 }
+
+  componentWillMount() {
+    this.props.getOneCI(this.props.courseId)
+    this.props.coursePageInformation(this.props.courseId)
+  }
 
   handleClick = (e, titleProps) => {
     const { index } = titleProps
@@ -166,4 +171,4 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps, { createOneComment, coursePageInformation })(BrowseReviews)
+export default connect(mapStateToProps, { createOneComment, getOneCI, coursePageInformation })(BrowseReviews)

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -3,7 +3,7 @@ import { Button, Table, Card, Form, Comment, List, Header, Label } from 'semanti
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { createOneComment } from '../../services/comment'
-import { coursePageInformation } from '../../services/courseInstance'
+import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import ReactMarkdown from 'react-markdown'
 
 class CoursePage extends Component {
@@ -22,6 +22,11 @@ class CoursePage extends Component {
     } catch (error) {
       console.log(error)
     }
+  }
+
+  componentWillMount() {
+    this.props.getOneCI(this.props.courseId)
+    this.props.coursePageInformation(this.props.courseId)
   }
 
   /**
@@ -230,14 +235,15 @@ class CoursePage extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
   return {
     user: state.user,
     studentInstance: state.studentInstance,
     teacherInstance: state.teacherInstance,
     selectedInstance: state.selectedInstance,
-    courseData: state.coursePage
+    courseData: state.coursePage,
+    courseId: ownProps.courseId
   }
 }
 
-export default connect(mapStateToProps, { createOneComment, coursePageInformation })(CoursePage)
+export default connect(mapStateToProps, { createOneComment, getOneCI, coursePageInformation })(CoursePage)

--- a/labtool2.0/src/components/pages/Courses.js
+++ b/labtool2.0/src/components/pages/Courses.js
@@ -3,10 +3,16 @@ import { Button, List, Container, Header, Table, Label } from 'semantic-ui-react
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 
+import { getAllCI } from '../../services/courseInstance'
+
 /**
  *  Show all the courses in a single list.
  */
 class Courses extends Component {
+  componentWillMount() {
+    this.props.getAllCI()
+  }
+
   render() {
     return (
       <div>
@@ -71,4 +77,4 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps, null)(Courses)
+export default connect(mapStateToProps, { getAllCI })(Courses)

--- a/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { Form, Input, Button, Grid, Radio } from 'semantic-ui-react'
-import { modifyOneCI } from '../../services/courseInstance'
+import { getOneCI, modifyOneCI } from '../../services/courseInstance'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Redirect } from 'react-router'
@@ -12,6 +12,7 @@ import { clearNotifications } from '../../reducers/notificationReducer'
 class ModifyCourseInstancePage extends Component {
   componentWillMount() {
     this.props.clearNotifications()
+    this.props.getOneCI(this.props.courseId)
   }
 
   componentDidUpdate() {
@@ -125,8 +126,9 @@ class ModifyCourseInstancePage extends Component {
 const mapStateToProps = (state, ownProps) => {
   return {
     selectedInstance: state.selectedInstance,
-    notification: state.notification
+    notification: state.notification,
+    courseId: ownProps.courseId
   }
 }
 
-export default connect(mapStateToProps, { modifyOneCI, clearNotifications })(ModifyCourseInstancePage)
+export default connect(mapStateToProps, { getOneCI, modifyOneCI, clearNotifications })(ModifyCourseInstancePage)

--- a/labtool2.0/src/components/pages/MyPage.js
+++ b/labtool2.0/src/components/pages/MyPage.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux'
 import { Button, Header, Table, Container, List, Icon, Segment, Divider } from 'semantic-ui-react'
 import './MyPage.css'
 import { Link } from 'react-router-dom'
+import { getAllStudentCourses } from '../../services/studentinstances'
+import { getAllTeacherCourses } from '../../services/teacherinstances'
 
 /**
  * The main page that is shown after user has logged in.
@@ -19,6 +21,11 @@ class MyPage extends Component {
     } catch (exception) {
       console.log('no user logged in')
     }
+  }
+
+  componentWillMount() {
+    this.props.getAllStudentCourses()
+    this.props.getAllTeacherCourses()
   }
 
   render() {
@@ -148,4 +155,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps, {})(MyPage)
+export default connect(mapStateToProps, { getAllStudentCourses, getAllTeacherCourses })(MyPage)

--- a/labtool2.0/src/components/pages/RegisterPage.js
+++ b/labtool2.0/src/components/pages/RegisterPage.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { createStudentCourses } from '../../services/studentinstances'
 import { Redirect } from 'react-router'
+import { getOneCI } from '../../services/courseInstance'
 
 /**
  * The page user uses to register to a course AS A STUDENT
@@ -29,6 +30,10 @@ class RegisterPage extends Component {
     } catch (error) {
       console.log(error)
     }
+  }
+
+  componentWillMount() {
+    this.props.getOneCI(this.props.courseId)
   }
 
   render() {
@@ -86,8 +91,9 @@ class RegisterPage extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    selectedInstance: state.selectedInstance
+    selectedInstance: state.selectedInstance,
+    courseId: ownProps.courseId
   }
 }
 
-export default connect(mapStateToProps, { createStudentCourses })(RegisterPage)
+export default connect(mapStateToProps, { createStudentCourses, getOneCI })(RegisterPage)

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -3,6 +3,7 @@ import { Button, Form, Input, Grid } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { createOneWeek } from '../../services/week'
+import { getOneCI } from '../../services/courseInstance'
 import { clearNotifications } from '../../reducers/notificationReducer'
 import store from '../../store'
 
@@ -11,6 +12,7 @@ import store from '../../store'
  */
 class ReviewStudent extends Component {
   componentWillMount() {
+    this.props.getOneCI(this.props.courseId)
     this.props.clearNotifications()
   }
 
@@ -83,4 +85,4 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps, { createOneWeek, clearNotifications })(ReviewStudent)
+export default connect(mapStateToProps, { createOneWeek, getOneCI, clearNotifications })(ReviewStudent)


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
## The problems

I noticed the frontend making unnecessary api calls. Many api calls were made twice or thrice, depending on the call. The culprit was App.js, more specifically, \<Main /> inside it. This method was making api calls inside a render()! It was also passing props that went unused in the component itself.

App was making certain api calls every time it was mounted. It was requesting certain resources from the backend with no respect to whether they were needed or not.

Deprecated props for App threatened to cause an infinite loop.

## The solutions

I refactored App.js so that it now makes no services calls. Service calls are instead made inside componentWillMount methods inside the appropriate components.

\<Main /> now only passes route params as props. Components use these props to make api calls.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
