### PR TITLE
Added optional setup.sh to be run before start.sh

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-if [ -e setup.sh ]
+if [ -e data/scripts_labtool_2018k/setup.sh ]
 then
-./setup.sh
+data/scripts_labtool_2018k/setup.sh
 fi
 NPM=`which npm`
 # $NPM dropdb # not sure if ok since production server db data should persist.

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+if [ -e setup.sh ]
+then
+./setup.sh
+fi
 NPM=`which npm`
 # $NPM dropdb # not sure if ok since production server db data should persist.
 $NPM run createdb # should fail if db already exists.


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
This is an attempt to allow custom scripts to be run depending on the server. This should let us drop the database on startup when on the test server, but not in production.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
