### PR TITLE
Fix github link on teacher's course view

### DIFF
--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -161,7 +161,7 @@ class CoursePage extends Component {
                     </Table.Cell>
                     <Table.Cell>
                       <p>{data.projectName}</p>
-                      <a>{data.github}</a>
+                      <a href={data.github}>{data.github}</a>
                     </Table.Cell>
                     {createIndents(data.weeks, data.id)}
                     <Table.Cell>{allPoints}</Table.Cell>


### PR DESCRIPTION
### Short description
Fixed teacher's course view to show an actual link to projects GitHub repository instead of just plain text.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
