### PR TITLE
Fix course links on My page and add superstudent

### DIFF
--- a/Kurki_simulation/responses/TKT20002.2018.K.K.1.js
+++ b/Kurki_simulation/responses/TKT20002.2018.K.K.1.js
@@ -2,7 +2,8 @@ exports.course = {
 	"students": [
 		"014893873",
     "014872455",
-    "014552657"
+    "014552657",
+    "014666666"
 	],
 	"teachers": [
 		"paaopettaja"

--- a/Kurki_simulation/responses/TKT20010.2018.K.A.1.js
+++ b/Kurki_simulation/responses/TKT20010.2018.K.A.1.js
@@ -2,7 +2,8 @@ exports.course = {
 	"students": [
 		"014578343",
     "014553242",
-    "014623598"
+    "014623598",
+    "014666666"
 	],
 	"teachers": [
 		"paaopettaja"

--- a/Kurki_simulation/responses/TKT20011.2018.K.A.1.js
+++ b/Kurki_simulation/responses/TKT20011.2018.K.A.1.js
@@ -1,7 +1,8 @@
 exports.course = {
 	"students": [
     "014845204",
-    "014952347"
+    "014952347",
+    "014666666"
   ],
 	"teachers": [
 		"paaopettaja"

--- a/Kurki_simulation/responses/TKT20012.2018.K.A.1.js
+++ b/Kurki_simulation/responses/TKT20012.2018.K.A.1.js
@@ -1,7 +1,8 @@
 exports.course = {
   "students": [
     "014732546",
-    "014564859"
+    "014564859",
+    "014666666"
   ],
   "teachers": [
     "paaopettaja"

--- a/Kurki_simulation/responses/users.js
+++ b/Kurki_simulation/responses/users.js
@@ -101,6 +101,12 @@ const users = [
     "student_number": "013554852",
     "first_names": "Ville Jussi",
     "last_name": "Toropainen"
+  },
+  {
+    "username": "superopiskelija",
+    "student_number": "014666666",
+    "first_names": "Teräs",
+    "last_name": "Henkilö"
   }
 ]
 

--- a/backend/server/seeders/20180326073413-demo-users.js
+++ b/backend/server/seeders/20180326073413-demo-users.js
@@ -80,6 +80,17 @@ module.exports = {
           createdAt: '2018-03-26',
           updatedAt: '2018-03-26',
           admin: false
+        },
+        {
+          id: 10031,
+          username: 'superopiskelija',
+          firsts: 'Teräs',
+          lastname: 'Henkilö',
+          email: 'teras.henkilo@helsinki.fi',
+          studentNumber: '014666666',
+          createdAt: '2018-03-26',
+          updatedAt: '2018-03-26',
+          admin: false
         }
       ],
       {}

--- a/backend/server/seeders/20180326074307-demo-studentInstances.js
+++ b/backend/server/seeders/20180326074307-demo-studentInstances.js
@@ -40,6 +40,33 @@ module.exports = {
           courseInstanceId: 10012,
           createdAt: '2018-03-26',
           updatedAt: '2018-03-26'
+        },
+        {
+          id: 10031,
+          github: 'http://github.com/superprojekti',
+          projectName: 'super projekti',
+          userId: 10031,
+          courseInstanceId: 10011,
+          createdAt: '2018-03-26',
+          updatedAt: '2018-03-26'
+        },
+        {
+          id: 10032,
+          github: 'http://github.com/superprojekti',
+          projectName: 'super projekti',
+          userId: 10031,
+          courseInstanceId: 10012,
+          createdAt: '2018-03-26',
+          updatedAt: '2018-03-26'
+        },
+        {
+          id: 10033,
+          github: 'http://github.com/superprojekti',
+          projectName: 'super projekti',
+          userId: 10031,
+          courseInstanceId: 10013,
+          createdAt: '2018-03-26',
+          updatedAt: '2018-03-26'
         }
       ],
       {}

--- a/labtool2.0/src/components/pages/MyPage.js
+++ b/labtool2.0/src/components/pages/MyPage.js
@@ -96,7 +96,9 @@ class MyPage extends Component {
               <Table.Body>
                 {this.props.studentInstance.map(sinstance => (
                   <Table.Row key={sinstance.id}>
-                    <Table.Cell>{sinstance.name}</Table.Cell>
+                    <Table.Cell>
+                      <Link to={`/labtool/courses/${sinstance.ohid}`}>{sinstance.name}</Link>
+                    </Table.Cell>
                     <Table.Cell textAlign="right">
                       <Link to={`/labtool/courses/${sinstance.ohid}`}>
                         <Button circular size="tiny" icon={{ name: 'eye', size: 'large', color: 'blue' }} />
@@ -120,7 +122,9 @@ class MyPage extends Component {
                   <Table.Body>
                     {this.props.teacherInstance.map(tinstance => (
                       <Table.Row key={tinstance.id}>
-                        <Table.Cell>{tinstance.name}</Table.Cell>
+                        <Table.Cell>
+                          <Link to={`/labtool/courses/${tinstance.ohid}`}>{tinstance.name} </Link>
+                        </Table.Cell>
                         <Table.Cell textAlign="right">
                           <Link to={`/labtool/courses/${tinstance.ohid}`}>
                             <Button circular size="tiny" icon={{ name: 'eye', size: 'large', color: 'blue' }} />


### PR DESCRIPTION
### Short description
The course names on My page now include a link to the respective course page. Also added a super student to the test data that attends three courses.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [x] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.

