### PR TITLE
Fix registering without WebOodi

### DIFF
--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -422,49 +422,65 @@ module.exports = {
    * @returns {Promise<Model>}
    */
   async retrieveCourseStuff(req, res) {
-    helper.controller_before_auth_check_action(req, res)
+    await helper.controller_before_auth_check_action(req, res)
 
-    try {
-      const course = await CourseInstance.findOne({
-        where: {
-          ohid: req.params.ohid
+    if (req.authenticated.success) {
+      try {
+        const currentUser = await User.findById(req.decoded.id)
+
+        if (!currentUser) {
+          return res.status(404).send('User not found')
         }
-      })
 
-      if (!course) {
-        return res.status(404).send({
-          message: 'Course not Found'
+        let checkRegistrationStatus = new Promise((resolve, reject) => {
+          helper.checkWebOodi(req, res, currentUser, resolve)
+          setTimeout(function() {
+            resolve('failure')
+          }, 5000)
         })
+
+        const registrationAtWebOodi = await checkRegistrationStatus
+
+        const course = await CourseInstance.findOne({
+          where: {
+            ohid: req.params.ohid
+          }
+        })
+
+        if (!course) {
+          return res.status(404).send('Course not found')
+        }
+
+        let teachers = await TeacherInstance.findAll({
+          where: {
+            courseInstanceId: course.id
+          }
+        })
+
+        const names = {}
+        const users = await User.findAll()
+        users.forEach(user => {
+          names[user.id] = {
+            firsts: user.firsts,
+            lastname: user.lastname
+          }
+        })
+
+        teachers = teachers.map(teacher => {
+          teacher.dataValues.firsts = names[teacher.userId].firsts
+          teacher.dataValues.lastname = names[teacher.userId].lastname
+          return teacher
+        })
+
+        console.log(teachers)
+
+        course.dataValues['teacherInstances'] = teachers
+        course.dataValues['registrationAtWebOodi'] = registrationAtWebOodi
+
+        return res.status(200).send(course)
+      } catch (exception) {
+        return res.status(400).send(exception)
       }
-
-      let teachers = await TeacherInstance.findAll({
-        where: {
-          courseInstanceId: course.id
-        }
-      })
-
-      const names = {}
-      const users = await User.findAll()
-      users.forEach(user => {
-        names[user.id] = {
-          firsts: user.firsts,
-          lastname: user.lastname
-        }
-      })
-
-      teachers = teachers.map(teacher => {
-        teacher.dataValues.firsts = names[teacher.userId].firsts
-        teacher.dataValues.lastname = names[teacher.userId].lastname
-        return teacher
-      })
-
-      console.log(teachers)
-
-      course.dataValues['teacherInstances'] = teachers
-
-      return res.status(200).send(course)
-    } catch (exception) {
-      return res.status(400).send(exception)
     }
   },
 

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -148,6 +148,13 @@ class CoursePage extends React.Component {
           {this.props.selectedInstance.active === true ? (
             this.props.courseData.role === 'teacher' || this.props.courseData.data !== null ? (
               <p />
+            ) : this.props.selectedInstance.registrationAtWebOodi === 'notfound' ? (
+              <div className="sixteen wide column">
+                <Message compact>
+                  <Message.Header>No registration found at WebOodi.</Message.Header>
+                  <p>If you have just registered, please try again in two hours.</p>
+                </Message>
+              </div>
             ) : (
               <div className="sixteen wide column">
                 <Link to={`/labtool/courseregistration/${this.props.selectedInstance.ohid}`}>


### PR DESCRIPTION
### Short description
Previously, students who had not registered to a course were able to input Project Name and Github link before getting an error message. Now, the registration status is checked when opening the course page, and if students are not registered to a course, the register button is replaced with a message saying 'No registration found at WebOodi'.

Fixes [#308](https://github.com/labtool/labtool/issues/308).

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [x] works in dev branch <!-- remove this line if your PR is not against master -->