### PR TITLE
Student course page shows code review info

### DIFF
--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -94,7 +94,7 @@ module.exports = {
           },
           {
             model: CodeReview,
-            attributes: ['toReview', 'reviewNumber'],
+            attributes: ['toReview', 'reviewNumber', 'points'],
             as: 'codeReviews',
             where: {
               reviewNumber: {
@@ -160,6 +160,7 @@ module.exports = {
                   projectName: cr.toReviews.projectName
                 },
                 reviewNumber: cr.reviewNumber,
+                points: cr.points,
                 reviewer: reviewers[cr.reviewNumber]
               }
             })

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -381,29 +381,33 @@ export class CoursePage extends React.Component {
                   this.props.courseData.data.codeReviews.map(
                     codeReview =>
                       codeReview.reviewNumber ? (
-                        <Card fluid color="yellow">
+                        <Card fluid color="yellow" key={codeReview.reviewNumber} className="codeReview">
                           <Card.Content header={'Code review ' + codeReview.reviewNumber} onClick={() => this.props.toggleCodeReview(codeReview.reviewNumber)} style={{ cursor: 'pointer' }} />
-                          <Card.Content style={{ display: this.props.coursePageLogic.showCodeReviews.indexOf(codeReview.reviewNumber) === -1 && codeReview.points === null ? 'none' : 'block' }}>{codeReview.points === null ? '' : codeReview.points + ' points'}</Card.Content>
-                          <div style={{ display: this.props.coursePageLogic.showCodeReviews.indexOf(codeReview.reviewNumber) === -1 ? 'none' : 'block' }}>
-                            <Card.Content>
-                              <h4>Project to review</h4>
-                              <p>{codeReview.toReview.projectName}</p>
-                              <p>
-                                <a href={codeReview.toReview.github}>{codeReview.toReview.github}</a>
-                              </p>
-                            </Card.Content>
-                            {codeReview.reviewer ? (
+                          {codeReview.points !== null ? <Card.Content className="codeReviewPoints">{codeReview.points + ' points'}</Card.Content> : <div />}
+                          {this.props.coursePageLogic.showCodeReviews.indexOf(codeReview.reviewNumber) !== -1 ? (
+                            <div className="codeReviewExpanded">
                               <Card.Content>
-                                <h4>Your reviewer</h4>
-                                <p>{codeReview.reviewer.projectName}</p>
+                                <h4>Project to review</h4>
+                                <p>{codeReview.toReview.projectName}</p>
                                 <p>
-                                  <a href={codeReview.reviewer.github}>{codeReview.reviewer.github}</a>
+                                  <a href={codeReview.toReview.github}>{codeReview.toReview.github}</a>
                                 </p>
                               </Card.Content>
-                            ) : (
-                              <div />
-                            )}
-                          </div>
+                              {codeReview.reviewer ? (
+                                <Card.Content>
+                                  <h4>Your reviewer</h4>
+                                  <p>{codeReview.reviewer.projectName}</p>
+                                  <p>
+                                    <a href={codeReview.reviewer.github}>{codeReview.reviewer.github}</a>
+                                  </p>
+                                </Card.Content>
+                              ) : (
+                                <div />
+                              )}
+                            </div>
+                          ) : (
+                            <div />
+                          )}
                         </Card>
                       ) : (
                         <div />

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -6,7 +6,7 @@ import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { associateTeacherToStudent } from '../../services/assistant'
 import ReactMarkdown from 'react-markdown'
-import { showDropdown, selectTeacher, filterByAssistant, coursePageReset } from '../../reducers/coursePageLogicReducer'
+import { showDropdown, selectTeacher, filterByAssistant, coursePageReset, toggleCodeReview } from '../../reducers/coursePageLogicReducer'
 
 export class CoursePage extends React.Component {
   handleSubmit = async e => {
@@ -382,25 +382,28 @@ export class CoursePage extends React.Component {
                     codeReview =>
                       codeReview.reviewNumber ? (
                         <Card fluid color="yellow">
-                          <Card.Content header={'Code review ' + codeReview.reviewNumber} />
-                          <Card.Content>
-                            <h4>Project to review</h4>
-                            <p>{codeReview.toReview.projectName}</p>
-                            <p>
-                              <a href={codeReview.toReview.github}>{codeReview.toReview.github}</a>
-                            </p>
-                          </Card.Content>
-                          {codeReview.reviewer ? (
+                          <Card.Content header={'Code review ' + codeReview.reviewNumber} onClick={() => this.props.toggleCodeReview(codeReview.reviewNumber)} style={{ cursor: 'pointer' }} />
+                          <Card.Content style={{ display: this.props.coursePageLogic.showCodeReviews.indexOf(codeReview.reviewNumber) === -1 && codeReview.points === null ? 'none' : 'block' }}>{codeReview.points === null ? '' : codeReview.points + ' points'}</Card.Content>
+                          <div style={{ display: this.props.coursePageLogic.showCodeReviews.indexOf(codeReview.reviewNumber) === -1 ? 'none' : 'block' }}>
                             <Card.Content>
-                              <h4>Your reviewer</h4>
-                              <p>{codeReview.reviewer.projectName}</p>
+                              <h4>Project to review</h4>
+                              <p>{codeReview.toReview.projectName}</p>
                               <p>
-                                <a href={codeReview.reviewer.github}>{codeReview.reviewer.github}</a>
+                                <a href={codeReview.toReview.github}>{codeReview.toReview.github}</a>
                               </p>
                             </Card.Content>
-                          ) : (
-                            <div />
-                          )}
+                            {codeReview.reviewer ? (
+                              <Card.Content>
+                                <h4>Your reviewer</h4>
+                                <p>{codeReview.reviewer.projectName}</p>
+                                <p>
+                                  <a href={codeReview.reviewer.github}>{codeReview.reviewer.github}</a>
+                                </p>
+                              </Card.Content>
+                            ) : (
+                              <div />
+                            )}
+                          </div>
                         </Card>
                       ) : (
                         <div />
@@ -432,4 +435,16 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps, { createOneComment, getOneCI, coursePageInformation, associateTeacherToStudent, showDropdown, selectTeacher, filterByAssistant, coursePageReset })(CoursePage)
+const mapDispatchToProps = {
+  createOneComment,
+  getOneCI,
+  coursePageInformation,
+  associateTeacherToStudent,
+  showDropdown,
+  selectTeacher,
+  filterByAssistant,
+  coursePageReset,
+  toggleCodeReview
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CoursePage)

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -333,30 +333,6 @@ export class CoursePage extends React.Component {
               </Card.Content>
             </Card>
 
-            <Card fluid color="yellow">
-              <Card.Content>
-                {this.props.courseData.data.codeReviews ? (
-                  this.props.courseData.data.codeReviews.map(
-                    codeReview =>
-                      codeReview.reviewNumber ? (
-                        <div>
-                          <div>
-                            <h4>Number: {codeReview.reviewNumber}</h4>
-                          </div>
-                          <div>
-                            <h4>Target: {codeReview.toReview}</h4>
-                          </div>
-                        </div>
-                      ) : (
-                        <div />
-                      )
-                  )
-                ) : (
-                  <h3>Ei ollut code reviewsejä</h3>
-                )}
-              </Card.Content>
-            </Card>
-
             <h3> Points and feedback </h3>
 
             <Table celled padded unstackable>
@@ -398,6 +374,43 @@ export class CoursePage extends React.Component {
                 ))}
               </Table.Body>
             </Table>
+
+            <Card fluid color="yellow">
+              <Card.Content>
+                {this.props.courseData.data.codeReviews ? (
+                  this.props.courseData.data.codeReviews.map(
+                    codeReview =>
+                      codeReview.reviewNumber ? (
+                        <Card fluid color="yellow">
+                          <Card.Content header={'Code review ' + codeReview.reviewNumber} />
+                          <Card.Content>
+                            <h4>Project to review</h4>
+                            <p>{codeReview.toReview.projectName}</p>
+                            <p>
+                              <a href={codeReview.toReview.github}>{codeReview.toReview.github}</a>
+                            </p>
+                          </Card.Content>
+                          {codeReview.reviewer ? (
+                            <Card.Content>
+                              <h4>Your reviewer</h4>
+                              <p>{codeReview.reviewer.projectName}</p>
+                              <p>
+                                <a href={codeReview.reviewer.github}>{codeReview.reviewer.github}</a>
+                              </p>
+                            </Card.Content>
+                          ) : (
+                            <div />
+                          )}
+                        </Card>
+                      ) : (
+                        <div />
+                      )
+                  )
+                ) : (
+                  <h3>Ei ollut code reviewsejä</h3>
+                )}
+              </Card.Content>
+            </Card>
           </div>
         ) : (
           <div />

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -333,6 +333,30 @@ export class CoursePage extends React.Component {
               </Card.Content>
             </Card>
 
+            <Card fluid color="yellow">
+              <Card.Content>
+                {this.props.courseData.data.codeReviews ? (
+                  this.props.courseData.data.codeReviews.map(
+                    codeReview =>
+                      codeReview.reviewNumber ? (
+                        <div>
+                          <div>
+                            <h4>Number: {codeReview.reviewNumber}</h4>
+                          </div>
+                          <div>
+                            <h4>Target: {codeReview.toReview}</h4>
+                          </div>
+                        </div>
+                      ) : (
+                        <div />
+                      )
+                  )
+                ) : (
+                  <h3>Ei ollut code reviewsejä</h3>
+                )}
+              </Card.Content>
+            </Card>
+
             <h3> Points and feedback </h3>
 
             <Table celled padded unstackable>

--- a/labtool2.0/src/reducers/coursePageLogicReducer.js
+++ b/labtool2.0/src/reducers/coursePageLogicReducer.js
@@ -9,7 +9,8 @@
 const INITIAL_STATE = {
   showDropdown: '',
   selectedTeacher: '',
-  filterByAssistant: 0
+  filterByAssistant: 0,
+  showCodeReviews: []
 }
 
 const coursePageLogicReducer = (state = INITIAL_STATE, action) => {
@@ -24,6 +25,27 @@ const coursePageLogicReducer = (state = INITIAL_STATE, action) => {
       return INITIAL_STATE
     case 'COURSE_PAGE_RESET':
       return INITIAL_STATE
+    case 'CP_INFO_SUCCESS':
+      if (action.response.role === 'student') {
+        try {
+          // This line sets showCodeReviews to be equal to the reviewNumbers whose points are 0.
+          return { ...state, showCodeReviews: action.response.data.codeReviews.filter(cr => cr.points === null).map(cr => cr.reviewNumber) }
+        } catch (e) {
+          console.log('ERROR: Setting initial values for shown codeReviews failed.')
+          return state
+        }
+      } else {
+        return state
+      }
+    case 'COURSE_PAGE_TOGGLE_CODE_REVIEW':
+      var index = state.showCodeReviews.indexOf(action.reviewNumber)
+      if (index === -1) {
+        return { ...state, showCodeReviews: [...state.showCodeReviews, action.reviewNumber] }
+      } else {
+        var newValue = state.showCodeReviews
+        newValue.splice(index, 1)
+        return { ...state, showCodeReviews: newValue }
+      }
     default:
       return state
   }
@@ -60,6 +82,15 @@ export const coursePageReset = () => {
   return async dispatch => {
     dispatch({
       type: 'COURSE_PAGE_RESET'
+    })
+  }
+}
+
+export const toggleCodeReview = reviewNumber => {
+  return async dispatch => {
+    dispatch({
+      type: 'COURSE_PAGE_TOGGLE_CODE_REVIEW',
+      reviewNumber
     })
   }
 }

--- a/labtool2.0/src/reducers/coursePageLogicReducer.js
+++ b/labtool2.0/src/reducers/coursePageLogicReducer.js
@@ -1,9 +1,10 @@
 /**
  * Named coursePageLogic in state.
  *
- * showDropdown: studentInstance, who the user is assigning a teacher to.
- * selectedTeacher: teacherInstance, who the user is assigning to a student.
- * filterByAssistant: teacherInstance, whose students are the only ones to be shown.
+ * showDropdown: studentInstance, who the user is assigning a teacher to. Teacher side.
+ * selectedTeacher: teacherInstance, who the user is assigning to a student. Teacher side.
+ * filterByAssistant: teacherInstance, whose students are the only ones to be shown. Teacher side.
+ * showCodeReviews: array of codeReviews to be shown uncollapsed. Student side.
  */
 
 const INITIAL_STATE = {
@@ -28,7 +29,7 @@ const coursePageLogicReducer = (state = INITIAL_STATE, action) => {
     case 'CP_INFO_SUCCESS':
       if (action.response.role === 'student') {
         try {
-          // This line sets showCodeReviews to be equal to the reviewNumbers whose points are 0.
+          // The line below sets showCodeReviews to be equal to the reviewNumbers whose points are 0.
           return { ...state, showCodeReviews: action.response.data.codeReviews.filter(cr => cr.points === null).map(cr => cr.reviewNumber) }
         } catch (e) {
           console.log('ERROR: Setting initial values for shown codeReviews failed.')

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -51,6 +51,20 @@ export default courseInstancereducer
                   }
               ]
           }
+      ],
+      "codeReviews": [
+          {
+              "reviewer": {
+                  "github": string, github link for reviewer
+                  "projectName": string, title for reviewer's project
+              }
+              "toReview": {
+                  "github": string, github link to repository user should review
+                  "projectName": string, title for project user should review
+              }
+              "reviewNumber": integer, indicates which round of code reviews this is.
+              "points": number or null, Points awarded for this code review. Null if not reviewed.
+          }
       ]
   }
 }

--- a/labtool2.0/src/tests/CoursePage.test.js
+++ b/labtool2.0/src/tests/CoursePage.test.js
@@ -245,6 +245,44 @@ describe('<CoursePage /> as student', () => {
           comments: []
         }
       ],
+      codeReviews: [
+        {
+          toReview: {
+            github: 'http://github.com/tiralabra2',
+            projectName: 'Tiran toinen labraprojekti'
+          },
+          reviewer: {
+            github: 'http://github.com/superprojekti',
+            projectName: 'Tira super projekti'
+          },
+          reviewNumber: 1,
+          points: 2.0
+        },
+        {
+          toReview: {
+            github: 'http://github.com/superprojekti',
+            projectName: 'Tira super projekti'
+          },
+          reviewer: {
+            github: 'http://github.com/tiralabra2',
+            projectName: 'Tiran toinen labraprojekti'
+          },
+          reviewNumber: 2,
+          points: 1.0
+        },
+        {
+          toReview: {
+            github: 'http://github.com/superprojekti',
+            projectName: 'Tira super projekti'
+          },
+          reviewer: {
+            github: 'http://github.com/tiralabra2',
+            projectName: 'Tiran toinen labraprojekti'
+          },
+          reviewNumber: 3,
+          points: null
+        }
+      ],
       User: {
         id: 10011,
         username: 'tiraopiskelija1',
@@ -259,10 +297,27 @@ describe('<CoursePage /> as student', () => {
     }
   }
 
+  const coursePageLogic = {
+    showDropdown: '',
+    selectedTeacher: '',
+    filterByAssistant: 0,
+    showCodeReviews: [2]
+  }
+
   let mockFn = jest.fn()
 
   beforeEach(() => {
-    wrapper = shallow(<CoursePage coursePage={coursePage} courseData={coursePage} getOneCI={mockFn} coursePageInformation={mockFn} associateTeacherToStudent={mockFn} selectedInstance={coursePage} />)
+    wrapper = shallow(
+      <CoursePage
+        coursePage={coursePage}
+        courseData={coursePage}
+        getOneCI={mockFn}
+        coursePageInformation={mockFn}
+        associateTeacherToStudent={mockFn}
+        selectedInstance={coursePage}
+        coursePageLogic={coursePageLogic}
+      />
+    )
   })
 
   describe('CoursePage Component', () => {
@@ -284,6 +339,18 @@ describe('<CoursePage /> as student', () => {
 
     it('doesnt render teachers view when role is student', () => {
       expect(wrapper.find('.TeachersView').length).toEqual(0)
+    })
+
+    it('renders code review cards', () => {
+      expect(wrapper.find('.codeReview').length).toEqual(coursePage.data.codeReviews.length)
+    })
+
+    it('collapses code review cards that are not shown', () => {
+      expect(wrapper.find('.codeReviewExpanded').length).toEqual(coursePageLogic.showCodeReviews.length)
+    })
+
+    it('renders collapsed code review points only if not null', () => {
+      expect(wrapper.find('.codeReviewPoints').length).toEqual(coursePage.data.codeReviews.filter(cr => cr.points !== null).length)
     })
   })
 })

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -329,9 +329,101 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
       fluid={true}
     >
       <CardContent>
-        <h3>
-          Ei ollut code reviewsejä
-        </h3>
+        <Card
+          className="codeReview"
+          color="yellow"
+          fluid={true}
+          key="1"
+        >
+          <CardContent
+            header="Code review 1"
+            onClick={[Function]}
+            style={
+              Object {
+                "cursor": "pointer",
+              }
+            }
+          />
+          <CardContent
+            className="codeReviewPoints"
+          >
+            2 points
+          </CardContent>
+          <div />
+        </Card>
+        <Card
+          className="codeReview"
+          color="yellow"
+          fluid={true}
+          key="2"
+        >
+          <CardContent
+            header="Code review 2"
+            onClick={[Function]}
+            style={
+              Object {
+                "cursor": "pointer",
+              }
+            }
+          />
+          <CardContent
+            className="codeReviewPoints"
+          >
+            1 points
+          </CardContent>
+          <div
+            className="codeReviewExpanded"
+          >
+            <CardContent>
+              <h4>
+                Project to review
+              </h4>
+              <p>
+                Tira super projekti
+              </p>
+              <p>
+                <a
+                  href="http://github.com/superprojekti"
+                >
+                  http://github.com/superprojekti
+                </a>
+              </p>
+            </CardContent>
+            <CardContent>
+              <h4>
+                Your reviewer
+              </h4>
+              <p>
+                Tiran toinen labraprojekti
+              </p>
+              <p>
+                <a
+                  href="http://github.com/tiralabra2"
+                >
+                  http://github.com/tiralabra2
+                </a>
+              </p>
+            </CardContent>
+          </div>
+        </Card>
+        <Card
+          className="codeReview"
+          color="yellow"
+          fluid={true}
+          key="3"
+        >
+          <CardContent
+            header="Code review 3"
+            onClick={[Function]}
+            style={
+              Object {
+                "cursor": "pointer",
+              }
+            }
+          />
+          <div />
+          <div />
+        </Card>
       </CardContent>
     </Card>
   </div>

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -324,6 +324,16 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
         </TableRow>
       </TableBody>
     </Table>
+    <Card
+      color="yellow"
+      fluid={true}
+    >
+      <CardContent>
+        <h3>
+          Ei ollut code reviewsejä
+        </h3>
+      </CardContent>
+    </Card>
   </div>
 </div>
 `;


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Add code review cards to the bottom of student side CoursePage. These cards will display who you should review and who reviews you. Cards with reviews that haven't been yet graded by a teacher appear expanded automatically. Cards appear collapsed, showing only the awarded points after being graded. The user may collapse/expand the cards by clicking on them. Points are not shown before the code review has been graded.

Also apply codeReview points to the backend response, since I forgot that earlier and need it now.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added actual code.
- [X] produced clean code.
- [X] code that actually does what it should.
- [X] documented the code or added documentation to the wiki.
- [X] added or modified test(s).
- [X] test(s) that actually pass.
