### PR TITLE
Current week is as default open in BrowseReviews

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -16,6 +16,7 @@ export class BrowseReviews extends Component {
   componentWillMount() {
     this.props.getOneCI(this.props.courseId)
     this.props.coursePageInformation(this.props.courseId)
+    this.setState({ activeIndex: this.props.selectedInstance.currentWeek - 1 })
   }
 
   handleClick = (e, titleProps) => {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#350
This issue has been written like a bug. So what is needed is that as a teacher you want to see current week being open, not the first week.
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
