### PR TITLE
Remove redundant student tag from add remove assistants

### DIFF
--- a/labtool2.0/src/components/pages/ModifyCourseInstanceStaff.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstanceStaff.js
@@ -88,9 +88,6 @@ export class ModifyCourseInstanceStaff extends React.Component {
                       )
                     ) : (
                       <div>
-                        <Label color="yellow" horizontal>
-                          Student
-                        </Label>
                         <Button onClick={this.handleSubmit(user.id)} size="tiny" color="green">
                           Add assistant
                         </Button>

--- a/labtool2.0/src/tests/ModifyCourseInstanceStaff.test.js
+++ b/labtool2.0/src/tests/ModifyCourseInstanceStaff.test.js
@@ -88,7 +88,7 @@ describe('<ModifyCourseInstanceStaff />', () => {
     })
 
     it('shows the correct amount of labels', () => {
-      expect(wrapper.find(Label).length).toEqual(3)
+      expect(wrapper.find(Label).length).toEqual(2)
     })
 
     it('shows the correct name and label for teacher of the course', () => {
@@ -100,14 +100,12 @@ describe('<ModifyCourseInstanceStaff />', () => {
 
     it('shows the correct name and label for student of the course', () => {
       const name = wrapper.find(Table.Cell).at(2)
-      const status = wrapper.find(Label).at(1)
       expect(name.props().children[0] + ' ' + name.props().children[2]).toEqual('Sivu Opiskelija')
-      expect(status.props().children).toEqual('Student')
     })
 
     it('shows the correct name and label for assistant of the course', () => {
       const name = wrapper.find(Table.Cell).at(4)
-      const status = wrapper.find(Label).at(2)
+      const status = wrapper.find(Label).at(1)
       expect(name.props().children[0] + ' ' + name.props().children[2]).toEqual('Aimo Assistentti')
       expect(status.props().children).toEqual('Assistant')
     })

--- a/labtool2.0/src/tests/__snapshots__/ModifyCourseInstanceStaff.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ModifyCourseInstanceStaff.test.js.snap
@@ -97,12 +97,6 @@ exports[`<ModifyCourseInstanceStaff /> Components renders correctly 1`] = `
             as="td"
           >
             <div>
-              <Label
-                color="yellow"
-                horizontal={true}
-              >
-                Student
-              </Label>
               <Button
                 as="button"
                 color="green"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
No issue number. This fix removes redundant 'Student' tag from add/remove assistants -page.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
