### PR TITLE
Filter students with tags on teachers' course page

### DIFF
--- a/backend/server/seeders/20180524100431-demo-studentInstances.js
+++ b/backend/server/seeders/20180524100431-demo-studentInstances.js
@@ -7,7 +7,7 @@ module.exports = {
       [
         {
           id: 10011,
-          github: 'http://github.com/tiralabra1',
+          github: 'http://github.com/tiraopi1/tiralabra1',
           projectName: 'Tiran labraprojekti',
           userId: 10011,
           courseInstanceId: 10011,
@@ -17,7 +17,7 @@ module.exports = {
         },
         {
           id: 10012,
-          github: 'http://github.com/tiralabra2',
+          github: 'http://github.com/tiraopi2/tiralabra2',
           projectName: 'Tiran toinen labraprojekti',
           userId: 10012,
           courseInstanceId: 10011,

--- a/backend/server/seeders/20180613072509-demo-tags.js
+++ b/backend/server/seeders/20180613072509-demo-tags.js
@@ -46,6 +46,13 @@ module.exports = {
           color: 'orange',
           createdAt: '2018-06-13',
           updatedAt: '2018-06-13'
+        },
+        {
+          id: 20007,
+          name: 'FORTRAN',
+          color: 'pink',
+          createdAt: '2018-06-13',
+          updatedAt: '2018-06-13'
         }
       ],
       {}

--- a/backend/server/seeders/20180613073528-demo-studenttags.js
+++ b/backend/server/seeders/20180613073528-demo-studenttags.js
@@ -29,7 +29,7 @@ module.exports = {
         {
           id: 30004,
           studentInstanceId: 10012,
-          tagId: 20006,
+          tagId: 20001,
           createdAt: '2018-06-13',
           updatedAt: '2018-06-13'
         },
@@ -44,6 +44,13 @@ module.exports = {
           id: 30006,
           studentInstanceId: 10021,
           tagId: 20004,
+          createdAt: '2018-06-13',
+          updatedAt: '2018-06-13'
+        },
+        {
+          id: 30007,
+          studentInstanceId: 10031,
+          tagId: 20007,
           createdAt: '2018-06-13',
           updatedAt: '2018-06-13'
         }

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -248,7 +248,7 @@ export class CoursePage extends React.Component {
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>Name</Table.HeaderCell>
-                  <Table.HeaderCell> Github </Table.HeaderCell>
+                  <Table.HeaderCell>Project Information</Table.HeaderCell>
                   {createHeaders()}
                   <Table.HeaderCell> Sum </Table.HeaderCell>
                   <Table.HeaderCell width="six"> Instructor </Table.HeaderCell>
@@ -266,16 +266,27 @@ export class CoursePage extends React.Component {
                         {data.User.firsts} {data.User.lastname}
                       </Table.Cell>
                       <Table.Cell>
-                        <p>{data.projectName}</p>
-                        <a href={data.github}>{data.github}</a>
+                        <p>
+                          {data.projectName}
+                          <br />
+                          <a href={data.github}>{data.github}</a>
+                        </p>
+                        {data.Tags.map(tag => (
+                          <div key={tag.id}>
+                            <Button compact floated="left" className={`mini ui ${tag.color} button`}>
+                              {tag.name}
+                            </Button>
+                          </div>
+                        ))}
                       </Table.Cell>
                       {createIndents(data.weeks, data.codeReviews, data.id)}
                       <Table.Cell>
                         {data.weeks.map(week => week.points).reduce((a, b) => {
                           return a + b
-                        }, 0) + data.codeReviews.map(cr => cr.points).reduce((a, b) => {
-                          return a + b
-                        }, 0)}
+                        }, 0) +
+                          data.codeReviews.map(cr => cr.points).reduce((a, b) => {
+                            return a + b
+                          }, 0)}
                       </Table.Cell>
                       <Table.Cell>
                         {data.teacherInstanceId && this.props.selectedInstance.teacherInstances ? (

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -6,7 +6,7 @@ import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { associateTeacherToStudent } from '../../services/assistant'
 import ReactMarkdown from 'react-markdown'
-import { showDropdown, selectTeacher, filterByAssistant, coursePageReset, toggleCodeReview } from '../../reducers/coursePageLogicReducer'
+import { showDropdown, selectTeacher, filterByAssistant, filterByTag, coursePageReset, toggleCodeReview } from '../../reducers/coursePageLogicReducer'
 
 export class CoursePage extends React.Component {
   handleSubmit = async e => {
@@ -52,6 +52,24 @@ export class CoursePage extends React.Component {
     return (e, data) => {
       const { value } = data
       this.props.filterByAssistant(value)
+    }
+  }
+
+  changeFilterTag = id => {
+    return () => {
+      if (this.props.coursePageLogic.filterByTag === id) {
+        this.props.filterByTag(0)
+      } else {
+        this.props.filterByTag(id)
+      }
+    }
+  }
+
+  hasFilteredTag = (data, id) => {
+    for (let i = 0; i < data.Tags.length; i++) {
+      if (data.Tags[i].id === id) {
+        return data
+      }
     }
   }
 
@@ -260,6 +278,9 @@ export class CoursePage extends React.Component {
                   .filter(data => {
                     return this.props.coursePageLogic.filterByAssistant === 0 || this.props.coursePageLogic.filterByAssistant === data.teacherInstanceId
                   })
+                  .filter(data => {
+                    return this.props.coursePageLogic.filterByTag === 0 || this.hasFilteredTag(data, this.props.coursePageLogic.filterByTag)
+                  })
                   .map(data => (
                     <Table.Row key={data.id}>
                       <Table.Cell>
@@ -273,7 +294,7 @@ export class CoursePage extends React.Component {
                         </p>
                         {data.Tags.map(tag => (
                           <div key={tag.id}>
-                            <Button compact floated="left" className={`mini ui ${tag.color} button`}>
+                            <Button compact floated="left" className={`mini ui ${tag.color} button`} onClick={this.changeFilterTag(tag.id)}>
                               {tag.name}
                             </Button>
                           </div>
@@ -479,6 +500,7 @@ const mapDispatchToProps = {
   showDropdown,
   selectTeacher,
   filterByAssistant,
+  filterByTag,
   coursePageReset,
   toggleCodeReview
 }

--- a/labtool2.0/src/reducers/coursePageLogicReducer.js
+++ b/labtool2.0/src/reducers/coursePageLogicReducer.js
@@ -11,6 +11,7 @@ const INITIAL_STATE = {
   showDropdown: '',
   selectedTeacher: '',
   filterByAssistant: 0,
+  filterByTag: 0,
   showCodeReviews: []
 }
 
@@ -22,6 +23,8 @@ const coursePageLogicReducer = (state = INITIAL_STATE, action) => {
       return { ...state, selectedTeacher: action.selection }
     case 'COURSE_PAGE_FILTER_BY_ASSISTANT':
       return { ...state, filterByAssistant: action.assistant }
+    case 'COURSE_PAGE_FILTER_BY_TAG':
+      return { ...state, filterByTag: action.tag }
     case 'ASSOCIATE_TEACHER_AND_STUDENT_SUCCESS':
       return INITIAL_STATE
     case 'COURSE_PAGE_RESET':
@@ -75,6 +78,15 @@ export const filterByAssistant = assistant => {
     dispatch({
       type: 'COURSE_PAGE_FILTER_BY_ASSISTANT',
       assistant
+    })
+  }
+}
+
+export const filterByTag = tag => {
+  return async dispatch => {
+    dispatch({
+      type: 'COURSE_PAGE_FILTER_BY_TAG',
+      tag
     })
   }
 }

--- a/labtool2.0/src/tests/CoursePage.test.js
+++ b/labtool2.0/src/tests/CoursePage.test.js
@@ -59,7 +59,14 @@ describe('<CoursePage /> as teacher', () => {
           admin: false,
           createdAt: '2018-03-26T00:00:00.000Z',
           updatedAt: '2018-03-26T00:00:00.000Z'
-        }
+        },
+        Tags: [
+          {
+            id: 20001,
+            name: 'Javascript',
+            color: 'red'
+          }
+        ]
       },
       {
         id: 10031,
@@ -82,7 +89,14 @@ describe('<CoursePage /> as teacher', () => {
           admin: false,
           createdAt: '2018-03-26T00:00:00.000Z',
           updatedAt: '2018-03-26T00:00:00.000Z'
-        }
+        },
+        Tags: [
+          {
+            id: 20002,
+            name: 'HTML',
+            color: 'yellow'
+          }
+        ]
       },
       {
         id: 10011,
@@ -146,7 +160,14 @@ describe('<CoursePage /> as teacher', () => {
           admin: false,
           createdAt: '2018-03-26T00:00:00.000Z',
           updatedAt: '2018-03-26T00:00:00.000Z'
-        }
+        },
+        Tags: [
+          {
+            id: 20005,
+            name: 'Node.js',
+            color: 'blue'
+          }
+        ]
       }
     ]
   }

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -145,13 +145,9 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
             as="td"
           >
             <ReactMarkdown
-              astPlugins={Array []}
               escapeHtml={true}
-              plugins={Array []}
-              rawSourcePos={false}
               renderers={Object {}}
               skipHtml={false}
-              sourcePos={false}
               transformLinkUri={[Function]}
             >
               Hienoa työtä!
@@ -204,13 +200,9 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
             as="td"
           >
             <ReactMarkdown
-              astPlugins={Array []}
               escapeHtml={true}
-              plugins={Array []}
-              rawSourcePos={false}
               renderers={Object {}}
               skipHtml={false}
-              sourcePos={false}
               transformLinkUri={[Function]}
             >
               Melko hienoa työtä!
@@ -263,13 +255,9 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
             as="td"
           >
             <ReactMarkdown
-              astPlugins={Array []}
               escapeHtml={true}
-              plugins={Array []}
-              rawSourcePos={false}
               renderers={Object {}}
               skipHtml={false}
-              sourcePos={false}
               transformLinkUri={[Function]}
             >
               Erittäin hienoa työtä!
@@ -322,13 +310,9 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
             as="td"
           >
             <ReactMarkdown
-              astPlugins={Array []}
               escapeHtml={true}
-              plugins={Array []}
-              rawSourcePos={false}
               renderers={Object {}}
               skipHtml={false}
-              sourcePos={false}
               transformLinkUri={[Function]}
             >
               Hyvin menee!
@@ -674,7 +658,7 @@ exports[`<CoursePage /> as teacher CoursePage Component should render correctly 
           <TableHeaderCell
             as="th"
           >
-             Github 
+            Project Information
           </TableHeaderCell>
           <TableHeaderCell
             as="th"
@@ -752,404 +736,7 @@ exports[`<CoursePage /> as teacher CoursePage Component should render correctly 
       </TableHeader>
       <TableBody
         as="tbody"
-      >
-        <TableRow
-          as="tr"
-          cellAs="td"
-          key="10012"
-        >
-          <TableCell
-            as="td"
-          >
-            Johan Wilhelm
-             
-            Studerande
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <p>
-              Tiran toinen labraprojekti
-            </p>
-            <a
-              href="http://github.com/tiralabra2"
-            >
-              http://github.com/tiralabra2
-            </a>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="0"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="1"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="2"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="3"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="4"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="5"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="6"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            0
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <span
-              key="10012"
-            >
-              Ossi Ohjaaja
-               
-              Mutikainen
-            </span>
-            <Icon
-              as="i"
-              name="pencil"
-              onClick={[Function]}
-              size="small"
-              style={
-                Object {
-                  "float": "right",
-                }
-              }
-            />
-            <div />
-          </TableCell>
-          <TableCell
-            as="td"
-            textAlign="right"
-          >
-            <Link
-              replace={false}
-              to="/labtool/browsereviews/TKT20010.2018.K.A.1/10012"
-            >
-              <Button
-                as="button"
-                circular={true}
-                icon={
-                  Object {
-                    "color": "orange",
-                    "name": "star",
-                    "size": "large",
-                  }
-                }
-                role="button"
-                size="tiny"
-              />
-            </Link>
-          </TableCell>
-        </TableRow>
-        <TableRow
-          as="tr"
-          cellAs="td"
-          key="10031"
-        >
-          <TableCell
-            as="td"
-          >
-            Teräs
-             
-            Henkilö
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <p>
-              Tira super projekti
-            </p>
-            <a
-              href="http://github.com/superprojekti"
-            >
-              http://github.com/superprojekti
-            </a>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="0"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="1"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="2"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="3"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="4"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="5"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="6"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            0
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <span
-              key="10031"
-            >
-              Ossi Ohjaaja
-               
-              Mutikainen
-            </span>
-            <Icon
-              as="i"
-              name="pencil"
-              onClick={[Function]}
-              size="small"
-              style={
-                Object {
-                  "float": "right",
-                }
-              }
-            />
-            <div />
-          </TableCell>
-          <TableCell
-            as="td"
-            textAlign="right"
-          >
-            <Link
-              replace={false}
-              to="/labtool/browsereviews/TKT20010.2018.K.A.1/10031"
-            >
-              <Button
-                as="button"
-                circular={true}
-                icon={
-                  Object {
-                    "color": "orange",
-                    "name": "star",
-                    "size": "large",
-                  }
-                }
-                role="button"
-                size="tiny"
-              />
-            </Link>
-          </TableCell>
-        </TableRow>
-        <TableRow
-          as="tr"
-          cellAs="td"
-          key="10011"
-        >
-          <TableCell
-            as="td"
-          >
-            Maarit Mirja
-             
-            Opiskelija
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <p>
-              Tiran labraprojekti
-            </p>
-            <a
-              href="http://github.com/tiralabra1"
-            >
-              http://github.com/tiralabra1
-            </a>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="0"
-          >
-            <p>
-              3
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="1"
-          >
-            <p>
-              2
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="2"
-          >
-            <p>
-              3
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="3"
-          >
-            <p>
-              3
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="4"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="5"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-            key="6"
-          >
-            <p>
-              -
-            </p>
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            11
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <span
-              key="10011"
-            >
-              Ossi Ohjaaja
-               
-              Mutikainen
-            </span>
-            <Icon
-              as="i"
-              name="pencil"
-              onClick={[Function]}
-              size="small"
-              style={
-                Object {
-                  "float": "right",
-                }
-              }
-            />
-            <div />
-          </TableCell>
-          <TableCell
-            as="td"
-            textAlign="right"
-          >
-            <Link
-              replace={false}
-              to="/labtool/browsereviews/TKT20010.2018.K.A.1/10011"
-            >
-              <Button
-                as="button"
-                circular={true}
-                icon={
-                  Object {
-                    "color": "orange",
-                    "name": "star",
-                    "size": "large",
-                  }
-                }
-                role="button"
-                size="tiny"
-              />
-            </Link>
-          </TableCell>
-        </TableRow>
-      </TableBody>
+      />
     </Table>
     <List
       style={


### PR DESCRIPTION
### Short description
Students can now be filtered on the teachers' course view page with tags. Filtering is currently based on one tag at a time.

PR also includes changes to seeders to accommodate (slightly) better filtering possibilities.

TODO: Similar filtering needs to be implemented to the code review page.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [X] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
