### PR TITLE
Filtering with tags on code review page

### DIFF
--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -262,7 +262,16 @@ export class CoursePage extends React.Component {
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>Name</Table.HeaderCell>
-                  <Table.HeaderCell>Project Information</Table.HeaderCell>
+                  <Table.HeaderCell>
+                    Project Info
+                    {this.props.coursePageLogic.filterByTag !== 0 ? (
+                      <Button compact className="mini ui yellow button" floated="right" onClick={this.changeFilterTag(0)}>
+                        Clear tag filter
+                      </Button>
+                    ) : (
+                      <p />
+                    )}
+                  </Table.HeaderCell>
                   {createHeaders()}
                   <Table.HeaderCell> Sum </Table.HeaderCell>
                   <Table.HeaderCell width="six"> Instructor </Table.HeaderCell>

--- a/labtool2.0/src/components/pages/ModifyCourseInstanceCodeReviews.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstanceCodeReviews.js
@@ -5,6 +5,7 @@ import { insertCodeReviews } from '../../services/codeReview'
 import { coursePageInformation } from '../../services/courseInstance'
 import { bulkinsertCodeReviews } from '../../services/codeReview'
 import { codeReviewReducer, initOneReview, initOrRemoveRandom, initCheckbox, initAllCheckboxes, randomAssign, codeReviewReset } from '../../reducers/codeReviewReducer'
+import { filterByTag } from '../../reducers/coursePageLogicReducer'
 import { clearNotifications } from '../../reducers/notificationReducer'
 import { Button, Table, Card, Form, Comment, List, Header, Label, Message, Icon, Dropdown, Checkbox } from 'semantic-ui-react'
 import Notification from '../../components/pages/Notification'
@@ -61,6 +62,25 @@ export class ModifyCourseInstanceReview extends React.Component {
       this.props.initAllCheckboxes({ data: allCb, ids: randoms })
     }
   }
+
+  changeFilterTag = id => {
+    return () => {
+      if (this.props.coursePageLogic.filterByTag === id) {
+        this.props.filterByTag(0)
+      } else {
+        this.props.filterByTag(id)
+      }
+    }
+  }
+
+  hasFilteredTag = (data, id) => {
+    for (let i = 0; i < data.Tags.length; i++) {
+      if (data.Tags[i].id === id) {
+        return data
+      }
+    }
+  }
+
   render() {
     const createHeaders = () => {
       const headers = []
@@ -91,42 +111,63 @@ export class ModifyCourseInstanceReview extends React.Component {
             <Table.Header>
               <Table.Row>
                 <Table.HeaderCell />
-                <Table.HeaderCell>Tags</Table.HeaderCell>
                 <Table.HeaderCell>Reviewer</Table.HeaderCell>
-                <Table.HeaderCell> Project </Table.HeaderCell>
+                <Table.HeaderCell>
+                  Project Info
+                  {this.props.coursePageLogic.filterByTag !== 0 ? (
+                    <Button compact className="mini ui yellow button" floated="right" onClick={this.changeFilterTag(0)}>
+                      Clear tag filter
+                    </Button>
+                  ) : (
+                    <p />
+                  )}
+                </Table.HeaderCell>
                 <Table.HeaderCell key={1}>Code Review 1 </Table.HeaderCell>
                 <Table.HeaderCell key={2}>Code Review 2 </Table.HeaderCell>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {this.props.courseData.data !== undefined
-                ? this.props.courseData.data.map(data => (
-                    <Table.Row key={data.id}>
-                      <Table.Cell>
-                        {this.props.codeReviewLogic.checkBoxStates[data.id] === true ? (
-                          <Checkbox checked onChange={this.initOrRemoveRandom(data.id)} />
-                        ) : (
-                          <Checkbox onChange={this.initOrRemoveRandom(data.id)} />
-                        )}
-                      </Table.Cell>
-                      <Table.Cell />
-                      <Table.Cell>
-                        {data.User.firsts} {data.User.lastname}
-                      </Table.Cell>
-                      <Table.Cell>
-                        <p>{data.projectName}</p>
-                        <a href={data.github}>{data.github}</a>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <p>Current review: {getCurrentReviewer(1, data.id)}</p>
-                        <select className="toReviewDropdown" onChange={this.addCodeReview(1, data.id)}>
-                          {this.props.dropdownUsers.map(d => (
-                            <option key={d.value} value={d.value}>
-                              {d.text}
-                            </option>
+                ? this.props.courseData.data
+                    .filter(data => {
+                      return this.props.coursePageLogic.filterByTag === 0 || this.hasFilteredTag(data, this.props.coursePageLogic.filterByTag)
+                    })
+                    .map(data => (
+                      <Table.Row key={data.id}>
+                        <Table.Cell>
+                          {this.props.codeReviewLogic.checkBoxStates[data.id] === true ? (
+                            <Checkbox checked onChange={this.initOrRemoveRandom(data.id)} />
+                          ) : (
+                            <Checkbox onChange={this.initOrRemoveRandom(data.id)} />
+                          )}
+                        </Table.Cell>
+                        <Table.Cell>
+                          {data.User.firsts} {data.User.lastname}
+                        </Table.Cell>
+                        <Table.Cell>
+                          <p>
+                            {data.projectName}
+                            <br />
+                            <a href={data.github}>{data.github}</a>
+                          </p>
+                          {data.Tags.map(tag => (
+                            <div key={tag.id}>
+                              <Button compact floated="left" className={`mini ui ${tag.color} button`} onClick={this.changeFilterTag(tag.id)}>
+                                {tag.name}
+                              </Button>
+                            </div>
                           ))}
-                        </select>
-                        {/*
+                        </Table.Cell>
+                        <Table.Cell>
+                          <p>Current review: {getCurrentReviewer(1, data.id)}</p>
+                          <select className="toReviewDropdown" onChange={this.addCodeReview(1, data.id)}>
+                            {this.props.dropdownUsers.map(d => (
+                              <option key={d.value} value={d.value}>
+                                {d.text}
+                              </option>
+                            ))}
+                          </select>
+                          {/*
                          Semantic ui dropdown works very slow so we replaced them with html select
                         }
                         {/* <Dropdown
@@ -139,10 +180,10 @@ export class ModifyCourseInstanceReview extends React.Component {
                         onChange={this.addCodeReview(1, data.id)}
                         value={this.props.codeReviewLogic.currentSelections[1][data.id]}
                       /> */}
-                      </Table.Cell>
-                      <Table.Cell>
-                        <p>Current review: {getCurrentReviewer(2, data.id)}</p>
-                        {/* <Dropdown
+                        </Table.Cell>
+                        <Table.Cell>
+                          <p>Current review: {getCurrentReviewer(2, data.id)}</p>
+                          {/* <Dropdown
                         className="toReviewDropdown"
                         placeholder="Select student"
                         fluid
@@ -152,16 +193,16 @@ export class ModifyCourseInstanceReview extends React.Component {
                         onChange={this.addCodeReview(2, data.id)}
                         value={this.props.codeReviewLogic.currentSelections[2][data.id]}
                       /> */}
-                        <select className="toReviewDropdown" onChange={this.addCodeReview(2, data.id)}>
-                          {this.props.dropdownUsers.map(d => (
-                            <option key={d.value} value={d.value}>
-                              {d.text}
-                            </option>
-                          ))}
-                        </select>
-                      </Table.Cell>
-                    </Table.Row>
-                  ))
+                          <select className="toReviewDropdown" onChange={this.addCodeReview(2, data.id)}>
+                            {this.props.dropdownUsers.map(d => (
+                              <option key={d.value} value={d.value}>
+                                {d.text}
+                              </option>
+                            ))}
+                          </select>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))
                 : null}
             </Table.Body>
             <Table.Footer>
@@ -171,7 +212,6 @@ export class ModifyCourseInstanceReview extends React.Component {
                     ALL
                   </Button>
                 </Table.HeaderCell>
-                <Table.HeaderCell />
                 <Table.HeaderCell />
                 <Table.HeaderCell />
                 <Table.HeaderCell>
@@ -224,6 +264,7 @@ const mapStateToProps = (state, ownProps) => {
     courseData: state.coursePage,
     selectedInstance: state.selectedInstance,
     codeReviewLogic: state.codeReviewLogic,
+    coursePageLogic: state.coursePageLogic,
     dropdownUsers: userHelper(state.coursePage.data)
   }
 }
@@ -238,10 +279,8 @@ const mapDispatchToProps = {
   initAllCheckboxes,
   bulkinsertCodeReviews,
   randomAssign,
-  codeReviewReset
+  codeReviewReset,
+  filterByTag
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ModifyCourseInstanceReview)
+export default connect(mapStateToProps, mapDispatchToProps)(ModifyCourseInstanceReview)

--- a/labtool2.0/src/tests/ModifyCourseInstanceCodeReviews.test.js
+++ b/labtool2.0/src/tests/ModifyCourseInstanceCodeReviews.test.js
@@ -187,6 +187,14 @@ describe('<ModifyCourseInstanceCodeReviews />', () => {
     initialized: false
   }
 
+  const coursePageLogic = {
+    showDropdown: '',
+    selectedTeacher: '',
+    filterByAssistant: 0,
+    filterByTag: 0,
+    showCodeReviews: []
+  }
+
   let mockFn = jest.fn()
 
   beforeEach(() => {
@@ -196,6 +204,7 @@ describe('<ModifyCourseInstanceCodeReviews />', () => {
         courseData={courseData}
         selectedInstance={coursePage}
         codeReviewLogic={codeReviewLogic}
+        coursePageLogic={coursePageLogic}
         dropdownUsers={userHelper(courseData.data)}
         clearNotifications={mockFn}
         getOneCI={mockFn}
@@ -207,6 +216,7 @@ describe('<ModifyCourseInstanceCodeReviews />', () => {
         bulkinsertCodeReviews={mockFn}
         randomAssign={mockFn}
         codeReviewReset={mockFn}
+        filterByTag={mockFn}
       />
     )
   })

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -436,7 +436,17 @@ exports[`<CoursePage /> as teacher CoursePage Component should render correctly 
           <TableHeaderCell
             as="th"
           >
-            Project Information
+            Project Info
+            <Button
+              as="button"
+              className="mini ui yellow button"
+              compact={true}
+              floated="right"
+              onClick={[Function]}
+              role="button"
+            >
+              Clear tag filter
+            </Button>
           </TableHeaderCell>
           <TableHeaderCell
             as="th"


### PR DESCRIPTION
### Short description
Added filtering with tags to the code review page. At the same time did a little reorganising and fitted tags in with project information similar to teachers' course page.

Also, due to the low visibility of the selected tag filter, added to both code review page and teachers' course page a button to clear tag filtering. It is something of a cludge, though. A better solution would be to format buttons so that the selection would be clearly visible. Such formatting is not supported out-of-the-box by Semantic UI, however. 

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [ ] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
