### PR TITLE
Add missing iterator keys to BrowseReviews

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -251,7 +251,7 @@ export class BrowseReviews extends Component {
               )
             } else {
               headers.push(
-                <Accordion key={i} fluid styled>
+                <Accordion key={i + ii + 1} fluid styled>
                   <Accordion.Title active={activeIndex === i} index={i} onClick={this.handleClick}>
                     <Icon name="dropdown" /> Final Review{' '}
                   </Accordion.Title>

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -72,7 +72,7 @@ export class BrowseReviews extends Component {
         // Tämä pitää myös korjata.
         if (student.id == studentInstance) {
           headers.push(
-            <Card fluid color="yellow">
+            <Card key={student.id} fluid color="yellow">
               <Card.Content>
                 <h2>
                   {student.User.firsts} {student.User.lastname}
@@ -121,7 +121,7 @@ export class BrowseReviews extends Component {
                                 </Comment.Content>
                               </Comment>
                             ) : (
-                              <Comment>
+                              <Comment key={comment.id}>
                                 <Comment.Author>{comment.from}</Comment.Author>
                                 <Comment.Text>
                                   {' '}
@@ -193,7 +193,7 @@ export class BrowseReviews extends Component {
             const finalWeek = student.weeks.find(week => week.weekNumber === this.props.selectedInstance.weekAmount + 1)
             if (finalWeek) {
               headers.push(
-                <Accordion key={i} fluid styled>
+                <Accordion key={i + ii + 1} fluid styled>
                   <Accordion.Title active={activeIndex === i + ii} index={i + ii} onClick={this.handleClick}>
                     <Icon name="dropdown" /> Final Review, points {finalWeek.points}
                   </Accordion.Title>


### PR DESCRIPTION
### Short description
Adds missing keys to Card, Comment and Accordion on BrowseReviews.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [ ] produced clean code.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.

