### PR TITLE
Email notification visibility

### DIFF
--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -706,7 +706,8 @@ module.exports = {
               weekId: message.week,
               hidden: message.hidden,
               comment: message.comment,
-              from: name
+              from: name,
+              notified: false
             })
               .then(comment => {
                 if (!comment) {

--- a/backend/server/controllers/weeks.js
+++ b/backend/server/controllers/weeks.js
@@ -48,7 +48,8 @@ module.exports = {
             points: req.body.points,
             studentInstanceId: req.body.studentInstanceId,
             feedback: req.body.feedback,
-            weekNumber: req.body.weekNumber
+            weekNumber: req.body.weekNumber,
+            notified: false
           })
           res.status(200).send(week)
         }

--- a/backend/server/migrations/20180621074213-comment-add-notified-column.js
+++ b/backend/server/migrations/20180621074213-comment-add-notified-column.js
@@ -2,14 +2,19 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('Comments', 'notified', {
+    queryInterface.addColumn('Comments', 'notified', {
       type: Sequelize.BOOLEAN,
       allowNull: false,
+      defaultValue: false
+    })
+    queryInterface.addColumn('Weeks', 'notified', {
+      type: Sequelize.BOOLEAN,
       defaultValue: false
     })
   },
 
   down: (queryInterface, Sequelize) => {
     queryInterface.removeColumn('Comments', 'notified')
+    queryInterface.removeColumn('Weeks', 'notified')
   }
 }

--- a/backend/server/migrations/20180621074213-comment-add-notified-column.js
+++ b/backend/server/migrations/20180621074213-comment-add-notified-column.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Comments', 'notified', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    queryInterface.removeColumn('Comments', 'notified')
+  }
+}

--- a/backend/server/models/comment.js
+++ b/backend/server/models/comment.js
@@ -17,6 +17,10 @@ module.exports = (sequelize, DataTypes) => {
       from: {
         type: DataTypes.STRING,
         allowNull: false
+      },
+      notified: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false
       }
     },
     {}

--- a/backend/server/models/week.js
+++ b/backend/server/models/week.js
@@ -4,7 +4,8 @@ module.exports = (sequelize, DataTypes) => {
     {
       points: DataTypes.DOUBLE,
       weekNumber: DataTypes.INTEGER,
-      feedback: DataTypes.STRING
+      feedback: DataTypes.STRING,
+      notified: DataTypes.BOOLEAN
     },
     {}
   )

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Button, Card, Accordion, Icon, Form, Comment, Input, Popup, Loader } from 'semantic-ui-react'
+import { Button, Card, Accordion, Icon, Form, Comment, Input, Popup, Loader, Label } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { createOneComment } from '../../services/comment'
@@ -118,10 +118,16 @@ export class BrowseReviews extends Component {
                           Weekly feedback: <ReactMarkdown>{weeks.feedback}</ReactMarkdown>{' '}
                         </h4>
                       </Card.Content>
-                      <Card.Content>
-                        <Button type="button" onClick={this.sendWeekEmail(weeks.id)}>
-                          Send email notification
-                        </Button>
+                      <Card.Content style={{ paddingBottom: '5px' }}>
+                        {weeks.notified ? (
+                          <Label>
+                            Notified <Icon name="check" color="green" />
+                          </Label>
+                        ) : (
+                          <Button type="button" onClick={this.sendWeekEmail(weeks.id)} size="small">
+                            Send email notification
+                          </Button>
+                        )}
                       </Card.Content>
                     </Card>
                     <h4> Comments </h4>
@@ -150,10 +156,16 @@ export class BrowseReviews extends Component {
                                   <ReactMarkdown>{comment.comment}</ReactMarkdown>{' '}
                                 </Comment.Text>
                                 {/* This hack compares user's name to comment.from and hides the email notification button when they don't match. */}
-                                {`${this.props.user.user.firsts} ${this.props.user.user.lastname}` === comment.from ? (
-                                  <Button type="button" onClick={this.sendCommentEmail(comment.id)}>
-                                    Send email notification
-                                  </Button>
+                                {comment.from.includes(this.props.user.user.lastname) ? (
+                                  comment.notified ? (
+                                    <Label>
+                                      Notified <Icon name="check" color="green" />
+                                    </Label>
+                                  ) : (
+                                    <Button type="button" onClick={this.sendCommentEmail(comment.id)} size="small">
+                                      Send email notification
+                                    </Button>
+                                  )
                                 ) : (
                                   <div />
                                 )}

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -339,10 +339,16 @@ export class CoursePage extends React.Component {
                                 <ReactMarkdown>{comment.comment}</ReactMarkdown>{' '}
                               </Comment.Text>
                               {/* This hack compares user's name to comment.from and hides the email notification button when they don't match. */}
-                              {`${this.props.user.user.firsts} ${this.props.user.user.lastname}` === comment.from ? (
-                                <Button type="button" onClick={this.sendEmail(comment.id)}>
-                                  Send email notification
-                                </Button>
+                              {comment.from.includes(this.props.user.user.lastname) ? (
+                                comment.notified ? (
+                                  <Label>
+                                    Notified <Icon name="check" color="green" />
+                                  </Label>
+                                ) : (
+                                  <Button type="button" onClick={this.sendEmail(comment.id)} size="small">
+                                    Send email notification
+                                  </Button>
+                                )
                               ) : (
                                 <div />
                               )}

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -5,6 +5,47 @@
  *
  */
 
+const teacherCommentNotification = (state, commentId) => {
+  const newData = [...state.data]
+  newData.forEach(student => {
+    student.weeks.forEach(week => {
+      week.comments.forEach(comment => {
+        if (comment.id === commentId) {
+          comment.notified = true
+          return { ...state, data: newData }
+        }
+      })
+    })
+  })
+  return state
+}
+
+const studentCommentNotification = (state, commentId) => {
+  const newWeeks = [...state.data.weeks]
+  newWeeks.forEach(week => {
+    week.comments.forEach(comment => {
+      if (comment.id === commentId) {
+        comment.notified = true
+        return { ...state, data: { ...state.data, weeks: newWeeks } }
+      }
+    })
+  })
+  return state
+}
+
+const weekNotification = (state, weekId) => {
+  const newData = [...state.data]
+  newData.forEach(student => {
+    student.weeks.forEach(week => {
+      if (week.id === weekId) {
+        week.notified = true
+        return { ...state, data: newData }
+      }
+    })
+  })
+  return state
+}
+
 const courseInstancereducer = (store = [], action) => {
   switch (action.type) {
     case 'CP_INFO_SUCCESS':
@@ -59,6 +100,16 @@ const courseInstancereducer = (store = [], action) => {
     case 'UNTAG_STUDENT_SUCCESS': {
       return { ...store, data: store.data.map(student => (student.id === action.response.id ? action.response : student)) }
     }
+    case 'SEND_EMAIL_SUCCESS':
+      if (store.role === 'teacher') {
+        if (action.response.data.commentId) {
+          return teacherCommentNotification(store, action.response.data.commentId)
+        } else {
+          return weekNotification(store, action.response.data.weekId)
+        }
+      } else {
+        return studentCommentNotification(store, action.response.data.commentId)
+      }
     default:
       return store
   }


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

#### Backend
* New column ```notified``` in ```Weeks``` and ```Comments``` tables.
* Marks weeks/comments as notified when email has been sent.

#### Frontend
* Send email notification buttons are disabled when a notification has already been sent.
* Reducer sets notified when notifying.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [X] added actual code.
- [X] produced clean code.
- [X] code that actually does what it should.
- [X] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
