### PR TITLE
Sort students alphabetically

### DIFF
--- a/labtool2.0/src/components/pages/ModifyCourseInstanceStaff.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstanceStaff.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { clearNotifications } from '../../reducers/notificationReducer'
 import { Table, Container, Header, Button, Label, Form, Loader } from 'semantic-ui-react'
 import { resetLoading } from '../../reducers/loadingReducer'
+import { sortUsersByAdminAssistantLastname } from '../../util/sort'
 
 export class ModifyCourseInstanceStaff extends React.Component {
   componentWillMount = async () => {
@@ -49,6 +50,10 @@ export class ModifyCourseInstanceStaff extends React.Component {
   }
 
   render() {
+    let sortedUsers = this.props.users
+    if (this.props.selectedInstance && this.props.selectedInstance.teacherInstances && this.props.users) {
+      sortedUsers = sortUsersByAdminAssistantLastname(this.props.users, this.props.selectedInstance.teacherInstances)
+    }
     return (
       <Container>
         <div className="sixteen wide column" style={{ textAlignVertical: 'center', textAlign: 'center' }}>
@@ -68,7 +73,7 @@ export class ModifyCourseInstanceStaff extends React.Component {
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {this.props.users.map(user => (
+                {sortedUsers.map(user => (
                   <Table.Row key={user.id}>
                     <Table.Cell>
                       {user.firsts} {user.lastname}
@@ -109,16 +114,6 @@ export class ModifyCourseInstanceStaff extends React.Component {
     )
   }
 }
-
-// const sortUsers = (users, selectedInstance) => {
-//   let teacherInstaceIds = []
-//   let usersWhoAreTeachers = []
-//   if (selectedInstance.teacherInstances) {
-//     teacherInstaceIds = selectedInstance.teacherInstances.map(f => f.userId)
-//     return users.filter(f => !teacherInstaceIds.includes(f.id))
-//   }
-//   return []
-// }
 
 const mapStateToProps = (state, ownProps) => {
   return {

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -1,3 +1,5 @@
+import { sortStudentsByLastname } from '../util/sort'
+
 /**
  * The reducer for displaying pretty much all that you want to see
  * on the course page.
@@ -49,7 +51,7 @@ const weekNotification = (state, weekId) => {
 const courseInstancereducer = (store = [], action) => {
   switch (action.type) {
     case 'CP_INFO_SUCCESS':
-      return action.response
+      return { ...action.response, data: sortStudentsByLastname(action.response.data) }
     case 'ASSOCIATE_TEACHER_AND_STUDENT_SUCCESS': {
       console.log(store)
       const id = action.response.id

--- a/labtool2.0/src/reducers/userReducer.js
+++ b/labtool2.0/src/reducers/userReducer.js
@@ -1,5 +1,3 @@
-import { sortUsers } from '../util/sort'
-
 /**
  * Named users in state. Contains all the users in the labtool database.
  */
@@ -12,7 +10,7 @@ const userReducer = (store = [], action) => {
           user.firsts = `username ${user.username}`
         }
       })
-      return sortUsers(users)
+      return users
     }
     default:
       return store

--- a/labtool2.0/src/tests/ModifyCourseInstanceStaff.test.js
+++ b/labtool2.0/src/tests/ModifyCourseInstanceStaff.test.js
@@ -119,12 +119,12 @@ describe('<ModifyCourseInstanceStaff />', () => {
     })
 
     it('shows the correct name and label for student of the course', () => {
-      const name = wrapper.find(Table.Cell).at(2)
+      const name = wrapper.find(Table.Cell).at(4)
       expect(name.props().children[0] + ' ' + name.props().children[2]).toEqual('Sivu Opiskelija')
     })
 
     it('shows the correct name and label for assistant of the course', () => {
-      const name = wrapper.find(Table.Cell).at(4)
+      const name = wrapper.find(Table.Cell).at(2)
       const status = wrapper.find(Label).at(1)
       expect(name.props().children[0] + ' ' + name.props().children[2]).toEqual('Aimo Assistentti')
       expect(status.props().children).toEqual('Assistant')

--- a/labtool2.0/src/tests/__snapshots__/ModifyCourseInstanceStaff.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ModifyCourseInstanceStaff.test.js.snap
@@ -84,34 +84,6 @@ exports[`<ModifyCourseInstanceStaff /> Components renders correctly 1`] = `
         <TableRow
           as="tr"
           cellAs="td"
-          key="10011"
-        >
-          <TableCell
-            as="td"
-          >
-            Sivu
-             
-            Opiskelija
-          </TableCell>
-          <TableCell
-            as="td"
-          >
-            <div>
-              <Button
-                as="button"
-                color="green"
-                onClick={[Function]}
-                role="button"
-                size="tiny"
-              >
-                Add assistant
-              </Button>
-            </div>
-          </TableCell>
-        </TableRow>
-        <TableRow
-          as="tr"
-          cellAs="td"
           key="10012"
         >
           <TableCell
@@ -139,6 +111,34 @@ exports[`<ModifyCourseInstanceStaff /> Components renders correctly 1`] = `
                 size="tiny"
               >
                 Remove assistant
+              </Button>
+            </div>
+          </TableCell>
+        </TableRow>
+        <TableRow
+          as="tr"
+          cellAs="td"
+          key="10011"
+        >
+          <TableCell
+            as="td"
+          >
+            Sivu
+             
+            Opiskelija
+          </TableCell>
+          <TableCell
+            as="td"
+          >
+            <div>
+              <Button
+                as="button"
+                color="green"
+                onClick={[Function]}
+                role="button"
+                size="tiny"
+              >
+                Add assistant
               </Button>
             </div>
           </TableCell>

--- a/labtool2.0/src/util/sort.js
+++ b/labtool2.0/src/util/sort.js
@@ -20,12 +20,40 @@ export const sortTags = tags => {
   })
 }
 
-export const sortUsers = users => {
+export const sortUsersByAdminAssistantLastname = (users, assistants) => {
   return users.sort((a, b) => {
-    if (a.admin === b.admin) {
-      return a.firsts < b.firsts ? -1 : 1
+    const aIsAssistant = assistants.find(ass => ass.userId === a.id)
+    const bIsAssistant = assistants.find(ass => ass.userId === b.id)
+    if (a.admin && !b.admin) {
+      return -1
+    } else if (!a.admin && b.admin) {
+      return 1
+    } else if (aIsAssistant && !bIsAssistant) {
+      return -1
+    } else if (!aIsAssistant && bIsAssistant) {
+      return 1
+    } else if (a.lastname > b.lastname) {
+      return -1
+    } else if (a.lastname < b.lastname) {
+      return 1
+    } else if (a.firsts > b.firsts) {
+      return -1
     } else {
-      return b.admin - a.admin
+      return 1
+    }
+  })
+}
+
+export const sortStudentsByLastname = students => {
+  return students.sort((a, b) => {
+    if (a.User.lastname < b.User.lastname) {
+      return -1
+    } else if (a.User.lastname > b.User.lastname) {
+      return 1
+    } else if (a.firsts < b.firsts) {
+      return -1
+    } else {
+      return 1
     }
   })
 }

--- a/labtool2.0/src/util/sort.js
+++ b/labtool2.0/src/util/sort.js
@@ -33,9 +33,9 @@ export const sortUsersByAdminAssistantLastname = (users, assistants) => {
     } else if (!aIsAssistant && bIsAssistant) {
       return 1
     } else if (a.lastname > b.lastname) {
-      return -1
-    } else if (a.lastname < b.lastname) {
       return 1
+    } else if (a.lastname < b.lastname) {
+      return -1
     } else if (a.firsts > b.firsts) {
       return -1
     } else {


### PR DESCRIPTION
### Short description
Shows students in an alphabetical order. In the modify course instance stuff page, shows users in order of whether they are admin or not, whether they are assistant or not and in alphabetical order (lastname first)

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
