### PR TITLE
Page updates after commenting

### DIFF
--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -703,7 +703,7 @@ module.exports = {
             return
           } else {
             const name = user.firsts.concat(' ').concat(user.lastname)
-            return Comment.create({
+            Comment.create({
               weekId: message.week,
               hidden: message.hidden,
               comment: message.comment,
@@ -714,7 +714,28 @@ module.exports = {
                 if (!comment) {
                   res.status(400).send('week not found')
                 } else {
-                  res.status(200).send(comment)
+                  Week.findOne({
+                    where: {
+                      id: message.week
+                    },
+                    include: [
+                      {
+                        model: Comment,
+                        attributes: {
+                          exclude: ['updatedAt']
+                        },
+                        as: 'comments'
+                      }
+                    ]
+                  }).then(week => {
+                    if (week) {
+                      res.status(200).send(week)
+                      return
+                    } else {
+                      res.status(400).send('something went wrong')
+                      return
+                    }
+                  })
                 }
               })
               .catch(error => res.status(400).send(error))

--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -710,34 +710,7 @@ module.exports = {
               from: name,
               notified: false
             })
-              .then(comment => {
-                if (!comment) {
-                  res.status(400).send('week not found')
-                } else {
-                  Week.findOne({
-                    where: {
-                      id: message.week
-                    },
-                    include: [
-                      {
-                        model: Comment,
-                        attributes: {
-                          exclude: ['updatedAt']
-                        },
-                        as: 'comments'
-                      }
-                    ]
-                  }).then(week => {
-                    if (week) {
-                      res.status(200).send(week)
-                      return
-                    } else {
-                      res.status(400).send('something went wrong')
-                      return
-                    }
-                  })
-                }
-              })
+              .then(comment => res.status(200).send(comment))
               .catch(error => res.status(400).send(error))
           }
         })

--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -710,7 +710,13 @@ module.exports = {
               from: name,
               notified: false
             })
-              .then(comment => res.status(200).send(comment))
+              .then(comment => {
+                if (!comment) {
+                  res.status(400).send('week not found')
+                } else {
+                  res.status(200).send(comment)
+                }
+              })
               .catch(error => res.status(400).send(error))
           }
         })

--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -703,7 +703,7 @@ module.exports = {
             return
           } else {
             const name = user.firsts.concat(' ').concat(user.lastname)
-            Comment.create({
+            return Comment.create({
               weekId: message.week,
               hidden: message.hidden,
               comment: message.comment,

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -44,9 +44,7 @@ export class BrowseReviews extends Component {
     }
     document.getElementById(e.target.name).reset()
     try {
-      console.log(e.target)
       await this.props.createOneComment(content)
-      await this.props.coursePageInformation(this.props.selectedInstance.ohid)
     } catch (error) {
       console.log(error)
     }

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -122,10 +122,13 @@ const courseInstancereducer = (store = [], action) => {
       }
     case 'COMMENT_CREATE_ONE_SUCCESS': {
       if (store.role === 'teacher') {
-        const newStudents = store.data.map(student => ({ ...student, weeks: student.weeks.map(week => (week.id === action.response.id ? action.response : week)) }))
+        const newStudents = store.data.map(student => ({
+          ...student,
+          weeks: student.weeks.map(week => (week.id === action.response.weekId ? { ...week, comments: [...week.comments, action.response] } : week))
+        }))
         return { ...store, data: newStudents }
       } else {
-        return { ...store, data: { ...store.data, weeks: store.data.weeks.map(week => (week.id === action.response.id ? action.response : week)) } }
+        return store
       }
     }
     default:

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -127,6 +127,10 @@ const courseInstancereducer = (store = [], action) => {
           weeks: student.weeks.map(week => (week.id === action.response.weekId ? { ...week, comments: [...week.comments, action.response] } : week))
         }))
         return { ...store, data: newStudents }
+      } else if (store.role === 'student') {
+        const newWeeks = [...store.data.weeks]
+        newWeeks.find(week => week.id === action.response.weekId).comments.push(action.response)
+        return { ...store, data: { ...store.data, weeks: newWeeks } }
       } else {
         return store
       }

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -112,13 +112,6 @@ const courseInstancereducer = (store = [], action) => {
     case 'UNTAG_STUDENT_SUCCESS': {
       return { ...store, data: store.data.map(student => (student.id === action.response.id ? action.response : student)) }
     }
-    case 'COMMENT_CREATE_ONE_SUCCESS':
-      if (store.role === 'student') {
-        const newWeeks = [...store.data.weeks]
-        newWeeks.find(week => week.id === action.response.weekId).comments.push(action.response)
-        return { ...store, data: { ...store.data, weeks: newWeeks } }
-      }
-      return store
     case 'SEND_EMAIL_SUCCESS':
       if (store.role === 'teacher') {
         if (action.response.data.commentId) {

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -121,8 +121,12 @@ const courseInstancereducer = (store = [], action) => {
         return studentCommentNotification(store, action.response.data.commentId)
       }
     case 'COMMENT_CREATE_ONE_SUCCESS': {
-      const newStudents = store.data.map(student => ({ ...student, weeks: student.weeks.map(week => (week.id === action.response.id ? action.response : week)) }))
-      return { ...store, data: newStudents }
+      if (store.role === 'teacher') {
+        const newStudents = store.data.map(student => ({ ...student, weeks: student.weeks.map(week => (week.id === action.response.id ? action.response : week)) }))
+        return { ...store, data: newStudents }
+      } else {
+        return { ...store, data: { ...store.data, weeks: store.data.weeks.map(week => (week.id === action.response.id ? action.response : week)) } }
+      }
     }
     default:
       return store

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -120,6 +120,10 @@ const courseInstancereducer = (store = [], action) => {
       } else {
         return studentCommentNotification(store, action.response.data.commentId)
       }
+    case 'COMMENT_CREATE_ONE_SUCCESS': {
+      const newStudents = store.data.map(student => ({ ...student, weeks: student.weeks.map(week => (week.id === action.response.id ? action.response : week)) }))
+      return { ...store, data: newStudents }
+    }
     default:
       return store
   }

--- a/labtool2.0/src/reducers/coursePageReducer.js
+++ b/labtool2.0/src/reducers/coursePageReducer.js
@@ -127,6 +127,7 @@ const courseInstancereducer = (store = [], action) => {
       } else {
         return studentCommentNotification(store, action.response.data.commentId)
       }
+    }
     case 'COMMENT_CREATE_ONE_SUCCESS': {
       if (store.role === 'teacher') {
         const newStudents = store.data.map(student => ({


### PR DESCRIPTION
### Short description
Now the course page reducer has a case about successful comment making. Both student and teacher can make a comment, after which the page updates, always. Before, there was a race condition, and it was pure luck if the page updated correctly after commenting.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
