### PR TITLE
Remove wrong stuff from unregistered students course page

### DIFF
--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -285,28 +285,26 @@ export class CoursePage extends React.Component {
       // studentInstance is id of student. Type: String
       // Tämä pitää myös korjata.
       headers.push(
-        <Card key="card" fluid color="yellow">
-          <Card.Content>
-            {this.props.courseData && this.props.courseData.data && this.props.courseData.data.User ? (
-              <h2>
-                {this.props.courseData.data.User.firsts} {this.props.courseData.data.User.lastname}
-              </h2>
-            ) : (
-              <div />
-            )}
-            {this.props.courseData && this.props.courseData.data ? <h3> {this.props.courseData.data.projectName} </h3> : <div />}
-            {this.props.courseData && this.props.courseData.data ? (
-              <h3>
-                <a href={this.props.courseData.data.github}>{this.props.courseData.data.github}</a>{' '}
-                <Link to={`/labtool/courseregistration/${this.props.selectedInstance.ohid}`}>
-                  <Button circular floated="right" size="large" icon={{ name: 'edit', color: 'orange', size: 'large' }} />
-                </Link>
-              </h3>
-            ) : (
-              <div />
-            )}
-          </Card.Content>
-        </Card>
+        <div>
+          {this.props.courseData && this.props.courseData.data && this.props.courseData.data.User ? (
+            <Card key="card" fluid color="yellow">
+              <Card.Content>
+                <h2>
+                  {this.props.courseData.data.User.firsts} {this.props.courseData.data.User.lastname}
+                </h2>
+                <h3> {this.props.courseData.data.projectName} </h3>
+                <h3>
+                  <a href={this.props.courseData.data.github}>{this.props.courseData.data.github}</a>{' '}
+                  <Link to={`/labtool/courseregistration/${this.props.selectedInstance.ohid}`}>
+                    <Button circular floated="right" size="large" icon={{ name: 'edit', color: 'orange', size: 'large' }} />
+                  </Link>
+                </h3>
+              </Card.Content>
+            </Card>
+          ) : (
+            <div />
+          )}
+        </div>
       )
       if (this.props.selectedInstance && this.props.courseData && this.props.courseData.data && this.props.courseData.data.weeks) {
         let i = 0
@@ -333,7 +331,6 @@ export class CoursePage extends React.Component {
                   <Comment.Group>
                     {week ? (
                       this.sortArrayAscendingByDate(week.comments).map(
-
                         comment =>
                           comment.hidden ? (
                             <Comment key={comment.id} disabled>
@@ -348,7 +345,8 @@ export class CoursePage extends React.Component {
                                 </Comment.Text>
                                 <Comment.Metadata>
                                   <div>{this.trimDate(comment.createdAt)}</div>
-                                </Comment.Metadata><div> </div>
+                                </Comment.Metadata>
+                                <div> </div>
                               </Comment.Content>
                             </Comment>
                           ) : (
@@ -360,7 +358,8 @@ export class CoursePage extends React.Component {
                               </Comment.Text>
                               <Comment.Metadata>
                                 <div>{this.trimDate(comment.createdAt)}</div>
-                              </Comment.Metadata><div> </div>
+                              </Comment.Metadata>
+                              <div> </div>
                               {/* This hack compares user's name to comment.from and hides the email notification button when they don't match. */}
                               {comment.from.includes(this.props.user.user.lastname) ? (
                                 comment.notified ? (
@@ -723,7 +722,6 @@ export class CoursePage extends React.Component {
                     <Button color="blue" size="large">
                       Register
                     </Button>
-                    <Popup trigger={<Button circular floated="right" size="large" icon={{ name: 'edit', color: 'orange', size: 'large' }} />} content="Edit project details" />
                   </Link>
                 </div>
               )
@@ -799,4 +797,7 @@ const mapDispatchToProps = {
   resetLoading
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CoursePage)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CoursePage)

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -285,7 +285,7 @@ export class CoursePage extends React.Component {
       // studentInstance is id of student. Type: String
       // Tämä pitää myös korjata.
       headers.push(
-        <div>
+        <div key="student info">
           {this.props.courseData && this.props.courseData.data && this.props.courseData.data.User ? (
             <Card key="card" fluid color="yellow">
               <Card.Content>

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -34,51 +34,55 @@ exports[`<CoursePage /> as student CoursePage Component should render correctly 
       </div>
     </div>
   </div>
-  <Card
-    color="yellow"
-    fluid={true}
-    key="card"
+  <div
+    key="student info"
   >
-    <CardContent>
-      <h2>
-        Maarit Mirja
-         
-        Opiskelija
-      </h2>
-      <h3>
-         
-        Tiran labraprojekti
-         
-      </h3>
-      <h3>
-        <a
-          href="http://github.com/tiralabra1"
-        >
-          http://github.com/tiralabra1
-        </a>
-         
-        <Link
-          replace={false}
-          to="/labtool/courseregistration/undefined"
-        >
-          <Button
-            as="button"
-            circular={true}
-            floated="right"
-            icon={
-              Object {
-                "color": "orange",
-                "name": "edit",
-                "size": "large",
+    <Card
+      color="yellow"
+      fluid={true}
+      key="card"
+    >
+      <CardContent>
+        <h2>
+          Maarit Mirja
+           
+          Opiskelija
+        </h2>
+        <h3>
+           
+          Tiran labraprojekti
+           
+        </h3>
+        <h3>
+          <a
+            href="http://github.com/tiralabra1"
+          >
+            http://github.com/tiralabra1
+          </a>
+           
+          <Link
+            replace={false}
+            to="/labtool/courseregistration/undefined"
+          >
+            <Button
+              as="button"
+              circular={true}
+              floated="right"
+              icon={
+                Object {
+                  "color": "orange",
+                  "name": "edit",
+                  "size": "large",
+                }
               }
-            }
-            role="button"
-            size="large"
-          />
-        </Link>
-      </h3>
-    </CardContent>
-  </Card>
+              role="button"
+              size="large"
+            />
+          </Link>
+        </h3>
+      </CardContent>
+    </Card>
+  </div>
   <Accordion
     fluid={true}
     key="0"


### PR DESCRIPTION
### Short description
Before, if you log in as a student who is not registered to a course and go to that course's page, the page shows an emtpy yellow card and "edit project info" button (round, yellow, with a pen icon). Now, it does not do that anymore.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
