### PR TITLE
Show total points on final review page

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -316,7 +316,7 @@ export class BrowseReviews extends Component {
                       <Button content="Add Reply" labelPosition="left" icon="edit" primary />
                     </Form>
                     <h3>Review</h3>
-                    <Link to={`/labtool/reviewstudent/${this.props.selectedInstance.ohid}/${studentInstance}/${i}`}>
+                    <Link to={`/labtool/reviewstudent/${this.props.selectedInstance.ohid}/${studentInstance}/${i + 1}`}>
                       <Popup trigger={<Button circular color="orange" size="tiny" icon={{ name: 'edit', color: 'black', size: 'large' }} />} content="Edit final review" />
                     </Link>
                   </Accordion.Content>

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -76,6 +76,15 @@ export class ReviewStudent extends Component {
     const studentData = this.props.courseData.data.filter(dataArray => dataArray.id === Number(this.props.ownProps.studentInstance))
     //this.props.weekNumber is a string, therefore casting to number.
     const weekData = studentData[0].weeks.filter(theWeek => theWeek.weekNumber === Number(this.props.ownProps.weekNumber))
+    const weekPoints = studentData[0].weeks
+      .filter(week => week.weekNumber < this.props.weekNumber)
+      .map(week => week.points)
+      .reduce((a, b) => {
+        return a + b
+      }, 0)
+    const codeReviewPoints = studentData[0].codeReviews.map(review => review.points).reduce((a, b) => {
+      return a + b
+    }, 0)
     const checkList = this.props.selectedInstance.checklists.find(checkl => checkl.week == this.props.ownProps.weekNumber)
     let checklistOutput = ''
     let checklistPoints = 0
@@ -102,11 +111,20 @@ export class ReviewStudent extends Component {
           {' '}
           {studentData[0].User.firsts} {studentData[0].User.lastname}{' '}
         </h3>
-        {this.props.weekNumber > this.props.selectedInstance.weekAmount ? <h1>Final Review</h1> : <h3>Viikko {this.props.weekNumber}</h3>}
+        {this.props.weekNumber > this.props.selectedInstance.weekAmount ? <h3>Final Review</h3> : <h3>Viikko {this.props.weekNumber}</h3>}
         <Grid>
           <Grid.Row columns={2}>
             <Grid.Column>
-              <h2>Feedback</h2>
+              {this.props.weekNumber > this.props.selectedInstance.weekAmount ? (
+                <div align="left">
+                  <h3>Point sum excluding final review: {weekPoints + codeReviewPoints} </h3>
+                  Week points: {weekPoints} <br />
+                  Code review points: {codeReviewPoints}
+                </div>
+              ) : (
+                <div />
+              )}
+              {this.props.weekNumber > this.props.selectedInstance.weekAmount ? <h2>Final Review Points</h2> : <h2>Feedback</h2>}
               <Form onSubmit={this.handleSubmit}>
                 <Form.Group inline unstackable>
                   <Form.Field>

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -117,12 +117,16 @@ export class ReviewStudent extends Component {
             <Grid.Column>
               {this.props.weekNumber > this.props.selectedInstance.weekAmount ? (
                 <div align="left">
-                  <h3>Point sum excluding final review: {weekPoints + codeReviewPoints} </h3>
+                  <h3>Points before final review: {weekPoints + codeReviewPoints} </h3>
                   Week points: {weekPoints} <br />
                   Code review points: {codeReviewPoints}
                 </div>
               ) : (
-                <div />
+                <div align="left">
+                  <h3>Points from previous weeks: {weekPoints + codeReviewPoints} </h3>
+                  Week points: {weekPoints} <br />
+                  Code review points: {codeReviewPoints}
+                </div>
               )}
               {this.props.weekNumber > this.props.selectedInstance.weekAmount ? <h2>Final Review Points</h2> : <h2>Feedback</h2>}
               <Form onSubmit={this.handleSubmit}>

--- a/labtool2.0/src/tests/ReviewStudent.test.js
+++ b/labtool2.0/src/tests/ReviewStudent.test.js
@@ -120,6 +120,7 @@ describe('<ReviewStudent />', () => {
           userId: 10012,
           teacherInstanceId: 10011,
           weeks: [],
+          codeReviews: [],
           User: {
             id: 10012,
             username: 'tiraopiskelija2',
@@ -142,6 +143,7 @@ describe('<ReviewStudent />', () => {
           userId: 10031,
           teacherInstanceId: 10011,
           weeks: [],
+          codeReviews: [],
           User: {
             id: 10031,
             username: 'superopiskelija',
@@ -205,6 +207,7 @@ describe('<ReviewStudent />', () => {
               comments: []
             }
           ],
+          codeReviews: [],
           User: {
             id: 10011,
             username: 'tiraopiskelija1',

--- a/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
@@ -29,6 +29,7 @@ exports[`<ReviewStudent /> ReviewStudent Component should render correctly 1`] =
       columns={2}
     >
       <GridColumn>
+        <div />
         <h2>
           Feedback
         </h2>

--- a/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
@@ -29,7 +29,21 @@ exports[`<ReviewStudent /> ReviewStudent Component should render correctly 1`] =
       columns={2}
     >
       <GridColumn>
-        <div />
+        <div
+          align="left"
+        >
+          <h3>
+            Points from previous weeks: 
+            0
+             
+          </h3>
+          Week points: 
+          0
+           
+          <br />
+          Code review points: 
+          0
+        </div>
         <h2>
           Feedback
         </h2>


### PR DESCRIPTION
### Short description
When doing a final review, teachers can now see students' point total so far (i.e. excluding the final review points).

The layout of the final review page is not exactly a sight for sore eyes, but things did not get that much worse, either.

Fixes #464.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
- [ ] works in dev branch <!-- remove this line if your PR is not against master -->
